### PR TITLE
Modify dual quaternion

### DIFF
--- a/s2e-ff/CMakeLists.txt
+++ b/s2e-ff/CMakeLists.txt
@@ -9,8 +9,8 @@ project(S2E_FF
 cmake_minimum_required(VERSION 3.13)
 
 # build config
-option(BUILD_64BIT "Build 64bit" OFF)
-option(GOOGLE_TEST "Execute GoogleTest" OFF)
+option(BUILD_64BIT "Build 64bit" ON)
+option(GOOGLE_TEST "Execute GoogleTest" ON)
 if (NOT BUILD_64BIT)
   option(GOOGLE_TEST OFF) # GoogleTest supports 64bit only
 endif()

--- a/s2e-ff/CMakeLists.txt
+++ b/s2e-ff/CMakeLists.txt
@@ -93,6 +93,8 @@ set(SOURCE_FILES
   src/Components/IdealComponents/RelativeAttitudeController.cpp
   src/Components/IdealComponents/InitializeRelativeAttitudeController.cpp
   src/Library/math/DualQuaternion.cpp
+  src/Library/math/RotationFirstDualQuaternion.cpp
+  src/Library/math/TranslationFirstDualQuaternion.cpp
   src/Simulation/Case/FfCase.cpp
   src/Simulation/Spacecraft/FfSat.cpp
   src/Simulation/Spacecraft/FfComponents.cpp
@@ -198,6 +200,10 @@ if(GOOGLE_TEST)
   set(TEST_FILES
     src/Library/math/DualQuaternion.cpp
     test/TestDualQuaternion.cpp
+    src/Library/math/RotationFirstDualQuaternion.cpp
+    test/TestRotationFirstDualQuaternion.cpp
+    src/Library/math/TranslationFirstDualQuaternion.cpp
+    test/TestTranslationFirstDualQuaternion.cpp
   )
   add_executable(${TEST_PROJECT_NAME} ${TEST_FILES})
   target_link_libraries(${TEST_PROJECT_NAME} gtest gtest_main)

--- a/s2e-ff/CMakeLists.txt
+++ b/s2e-ff/CMakeLists.txt
@@ -9,8 +9,8 @@ project(S2E_FF
 cmake_minimum_required(VERSION 3.13)
 
 # build config
-option(BUILD_64BIT "Build 64bit" ON)
-option(GOOGLE_TEST "Execute GoogleTest" ON)
+option(BUILD_64BIT "Build 64bit" OFF)
+option(GOOGLE_TEST "Execute GoogleTest" OFF)
 if (NOT BUILD_64BIT)
   option(GOOGLE_TEST OFF) # GoogleTest supports 64bit only
 endif()

--- a/s2e-ff/src/Library/math/DualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/DualQuaternion.cpp
@@ -22,6 +22,13 @@ DualQuaternion::DualQuaternion(const double q_real_x, const double q_real_y, con
 }
 
 // Calculations
+DualQuaternion DualQuaternion::Properization() const {
+  if (this->GetRealPart()[3] > 0.0) {
+    return *this;
+  }
+  return -1.0 * (*this);
+}
+
 DualQuaternion DualQuaternion::DualNumberConjugate() const {
   Quaternion q_real_out = q_real_;
   Quaternion q_dual_out = -1.0 * q_dual_;

--- a/s2e-ff/src/Library/math/DualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/DualQuaternion.cpp
@@ -70,8 +70,8 @@ Vector<3> DualQuaternion::InverseTransformVector(const Vector<3>& v) const {
   return v_out;
 }
 
-SkrewParameters DualQuaternion::CalcSkrewParameters() const {
-  SkrewParameters out;
+ScrewParameters DualQuaternion::CalcScrewParameters() const {
+  ScrewParameters out;
 
   Vector<3> real_vector_part;
   for (int i = 0; i < 3; i++) real_vector_part[i] = this->GetRealPart()[i];

--- a/s2e-ff/src/Library/math/DualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/DualQuaternion.cpp
@@ -21,42 +21,7 @@ DualQuaternion::DualQuaternion(const double q_real_x, const double q_real_y, con
   q_dual_ = Quaternion(q_dual_x, q_dual_y, q_dual_z, q_dual_w);
 }
 
-DualQuaternion::DualQuaternion(const Quaternion q_rot, const Vector<3> v_translation) {
-  q_real_ = q_rot;
-  q_real_.normalize();
-
-  // TODO: Make vector * quaternion function in core's Quaternion class
-  Quaternion q_v(v_translation[0], v_translation[1], v_translation[2], 0.0);
-  q_dual_ = 0.5 * (q_v * q_real_);
-}
-
-DualQuaternion::DualQuaternion(const Vector<3> v_translation, const Quaternion q_rot) {
-  q_real_ = q_rot;
-  q_real_.normalize();
-
-  // TODO: Make vector * quaternion function in core's Quaternion class
-  Quaternion q_v(v_translation[0], v_translation[1], v_translation[2], 0.0);
-  q_dual_ = 0.5 * (q_real_ * q_v);
-}
-
 // Calculations
-DualQuaternion DualQuaternion::CalcNormalizedRotationQauternion() const {
-  Quaternion q_rot = q_real_;
-  Vector<3> v_translation = this->GetRotationFirstTranslationVector();
-  q_rot.normalize();
-
-  DualQuaternion dq_out(q_rot, v_translation);
-  return dq_out;
-}
-
-void DualQuaternion::NormalizeRotationQauternion() {
-  Vector<3> v_translation = this->GetRotationFirstTranslationVector();
-  q_real_.normalize();
-
-  DualQuaternion dq_out(q_real_, v_translation);
-  q_dual_ = dq_out.GetDualPart();
-}
-
 DualQuaternion DualQuaternion::DualNumberConjugate() const {
   Quaternion q_real_out = q_real_;
   Quaternion q_dual_out = -1.0 * q_dual_;
@@ -98,39 +63,6 @@ Vector<3> DualQuaternion::InverseTransformVector(const Vector<3>& v) const {
   return v_out;
 }
 
-DualQuaternion DualQuaternion::Differential(const Vector<3>& omega, const Vector<3>& velocity) const {
-  Quaternion q_omega(omega[0], omega[1], omega[2], 0.0);
-  Quaternion q_velocity(velocity[0], velocity[1], velocity[2], 0.0);
-
-  Quaternion q_real_out = 0.5 * q_omega * q_real_;
-  Quaternion q_dual_out = 0.5 * ((q_velocity * q_real_) + 0.5 * (q_velocity * q_omega * q_real_));
-
-  DualQuaternion dq_out(q_real_out, q_dual_out);
-  return dq_out;
-}
-
-DualQuaternion DualQuaternion::Integrate(const Vector<3>& omega, const Vector<3>& velocity, const double dt) const {
-  DualQuaternion diff_dq = this->Differential(omega, velocity);
-  DualQuaternion dq_out = (*this) + dt * diff_dq;
-  dq_out.NormalizeRotationQauternion();
-  return dq_out;
-}
-
-// Getters
-Vector<3> DualQuaternion::GetRotationFirstTranslationVector() const {
-  Quaternion q_out = 2.0 * q_dual_ * q_real_.conjugate();
-  Vector<3> v_out;
-  for (int i = 0; i < 3; i++) v_out[i] = q_out[i];
-  return v_out;
-}
-
-Vector<3> DualQuaternion::GetTranslationFirstTranslationVector() const {
-  Quaternion q_out = 2.0 * q_real_.conjugate() * q_dual_;
-  Vector<3> v_out;
-  for (int i = 0; i < 3; i++) v_out[i] = q_out[i];
-  return v_out;
-}
-
 // Operation functions
 DualQuaternion operator+(const DualQuaternion& dq_lhs, const DualQuaternion& dq_rhs) {
   Quaternion q_real_out = dq_lhs.GetRealPart() + dq_rhs.GetRealPart();
@@ -156,39 +88,6 @@ DualQuaternion operator*(const DualQuaternion& dq_lhs, const DualQuaternion& dq_
   Quaternion q_real_out = dq_lhs.GetRealPart() * dq_rhs.GetRealPart();
   Quaternion q_dual_out = (dq_lhs.GetRealPart() * dq_rhs.GetDualPart()) + (dq_lhs.GetDualPart() * dq_rhs.GetRealPart());
   DualQuaternion dq_out(q_real_out, q_dual_out);
-  return dq_out;
-}
-
-DualQuaternion Sclerp(const DualQuaternion dq1, const DualQuaternion dq2, const double tau) {
-  if (tau < 0.0) return dq1;
-  if (tau > 1.0) return dq1;
-
-  DualQuaternion dq1_inv = dq1.Inverse();
-  DualQuaternion dq12 = dq1_inv * dq2;
-
-  // Calc rotation angle and axis
-  // TODO: make function in core's quaternion library
-  double theta = 2.0 * acos(dq12.GetRealPart()[3]);
-  Vector<3> axis;
-  if (theta < 0.0 + DBL_MIN) {
-    // No rotation
-    axis = dq12.GetRotationFirstTranslationVector();
-  } else {
-    for (int i = 0; i < 3; i++) axis[i] = dq12.GetRealPart()[i];
-  }
-  normalize(axis);
-
-  // Calc (dq1^-1 * dq2)^tau
-  double d = dot(dq12.GetRotationFirstTranslationVector(), axis);
-  Quaternion dq12_tau_real(axis, tau * theta);
-  Quaternion dq12_tau_dual;
-  for (int i = 0; i < 3; i++) dq12_tau_dual[i] = cos(tau * theta * 0.5) * axis[i];
-  dq12_tau_dual[3] = -sin(tau * theta * 0.5);
-  dq12_tau_dual = (0.5 * tau * d) * dq12_tau_dual;
-  DualQuaternion dq12_tau(dq12_tau_real, dq12_tau_dual);
-
-  // Calc interpolated dual quaternion
-  DualQuaternion dq_out = dq1 * dq12_tau;
   return dq_out;
 }
 

--- a/s2e-ff/src/Library/math/DualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/DualQuaternion.cpp
@@ -112,6 +112,21 @@ ScrewParameters DualQuaternion::CalcScrewParameters() const {
   return out;
 }
 
+DualQuaternion DualQuaternion::Power(const double tau) const {
+  ScrewParameters screw = this->CalcScrewParameters();
+
+  Quaternion dq_out_real(screw.axis_, tau * screw.angle_rad_);
+  Quaternion dq_out_dual;
+  double ang = tau * screw.angle_rad_ * 0.5;
+
+  for (int i = 0; i < 3; i++) {
+    dq_out_dual[i] = (0.5 * tau * screw.pitch_) * cos(ang) * screw.axis_[i] + sin(ang) * screw.moment_[i];
+  }
+  dq_out_dual[3] = -(0.5 * tau * screw.pitch_) * sin(ang);
+  DualQuaternion dq_out(dq_out_real, dq_out_dual);
+  return dq_out;
+}
+
 // Operation functions
 DualQuaternion operator+(const DualQuaternion& dq_lhs, const DualQuaternion& dq_rhs) {
   Quaternion q_real_out = dq_lhs.GetRealPart() + dq_rhs.GetRealPart();

--- a/s2e-ff/src/Library/math/DualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/DualQuaternion.hpp
@@ -4,6 +4,14 @@
 
 namespace libra {
 
+class SkrewParameters {
+ public:
+  Vector<3> axis_;
+  double angle_rad_;
+  Vector<3> moment_;
+  double pitch_;
+};
+
 /**
  * @class DualQuaternion
  * @brief Frame conversion sequence: Rotation -> Translation
@@ -73,6 +81,12 @@ class DualQuaternion {
    */
   Vector<3> InverseTransformVector(const Vector<3>& v) const;
 
+  /**
+   * @fn Calculate skrew parameters from dual quaternion
+   * @param[out] return: Skrew parameters
+   */
+  SkrewParameters CalcSkrewParameters() const;
+
   // Getter
   inline Quaternion GetRealPart() const { return q_real_; }
   inline Quaternion GetDualPart() const { return q_dual_; }
@@ -81,6 +95,15 @@ class DualQuaternion {
  protected:
   Quaternion q_real_;  //!< Real part Quaternion
   Quaternion q_dual_;  //!< Dual part Quaternion
+
+  /**
+   * @fn Screw Linear Interpolation without
+   * @param[in]  dq1: First dual quaternion
+   * @param[in]  dq2: Second dual quaternion
+   * @param[in]  tau: Interpolation coefficients [0, 1]
+   * @param[out] return: Interpolated dual quaternion
+   */
+  //  DualQuaternion Sclerp(const DualQuaternion dq1, const DualQuaternion dq2, const double tau);
 };
 
 // Operation functions

--- a/s2e-ff/src/Library/math/DualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/DualQuaternion.hpp
@@ -87,6 +87,13 @@ class DualQuaternion {
    */
   ScrewParameters CalcScrewParameters() const;
 
+  /**
+   * @fn Calculate dq^(tau)
+   * @param[in]  tau: Exponents
+   * @param[out] return: Screw parameters
+   */
+  DualQuaternion Power(const double tau) const;
+
   // Getter
   inline Quaternion GetRealPart() const { return q_real_; }
   inline Quaternion GetDualPart() const { return q_dual_; }

--- a/s2e-ff/src/Library/math/DualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/DualQuaternion.hpp
@@ -32,37 +32,7 @@ class DualQuaternion {
   DualQuaternion(const double q_real_x, const double q_real_y, const double q_real_z, const double q_real_w, const double q_dual_x,
                  const double q_dual_y, const double q_dual_z, const double q_dual_w);
 
-  /**
-   * @fn Constructor
-   * @brief Make from rotation quaternion and translation vector
-   *        Frame conversion sequence: Rotation -> Translation
-   * @param[in] q_rot: Quaternion for rotation. This quaternion is used after normalized in this function.
-   * @param[in] v_translation: Vector for translation
-   */
-  DualQuaternion(const Quaternion q_rot, const Vector<3> v_translation);
-
-  /**
-   * @fn Constructor
-   * @brief Make from rotation quaternion and translation vector
-   *        Frame conversion sequence: Translation -> Rotation
-   * @param[in] q_rot: Quaternion for rotation. This quaternion is used after normalized in this function.
-   * @param[in] v_translation: Vector for translation
-   */
-  DualQuaternion(const Vector<3> v_translation, const Quaternion q_rot);
-
   // Operator for a single dual quaternon
-  /**
-   * @fn Normalize rotation quaternion
-   * @brief This function doesn't change the original DualQuaternion value
-   */
-  DualQuaternion CalcNormalizedRotationQauternion() const;
-
-  /**
-   * @fn Normalize rotation quaternion
-   * @brief This function changes the original DualQuaternion value
-   */
-  void NormalizeRotationQauternion();
-
   /**
    * @fn Calulate conjugated of the dual quaternion as dual number
    */
@@ -98,31 +68,12 @@ class DualQuaternion {
    */
   Vector<3> InverseTransformVector(const Vector<3>& v) const;
 
-  /**
-   * @fn Differential equation of dual quaternion
-   * @param[in]  omega: Angular velocity [rad/s]
-   * @param[in]  velocity: Velocity [-]
-   * @param[out] return: Differential of dual equation
-   */
-  DualQuaternion Differential(const Vector<3>& omega, const Vector<3>& velocity) const;
-
-  /**
-   * @fn Differential equation of dual quaternion
-   * @param[in]  omega: Angular velocity [rad/s]
-   * @param[in]  velocity: Velocity [-]
-   * @param[in]  dt: Differential time [s]
-   * @param[out] return: Integrated dual equation
-   */
-  DualQuaternion Integrate(const Vector<3>& omega, const Vector<3>& velocity, const double dt) const;
-
   // Getter
   inline Quaternion GetRealPart() const { return q_real_; }
   inline Quaternion GetDualPart() const { return q_dual_; }
   inline Quaternion GetRotationQuaternion() const { return q_real_; }
-  Vector<3> GetRotationFirstTranslationVector() const;
-  Vector<3> GetTranslationFirstTranslationVector() const;
 
- private:
+ protected:
   Quaternion q_real_;  //!< Real part Quaternion
   Quaternion q_dual_;  //!< Dual part Quaternion
 };
@@ -155,15 +106,5 @@ DualQuaternion operator*(const double& scalar, const DualQuaternion& dq);
  * @param[in] dq_rhs: Dual Quaternion right hand side
  */
 DualQuaternion operator*(const DualQuaternion& dq_lhs, const DualQuaternion& dq_rhs);
-
-/**
- * @fn Screw Linear Interpolation
- * @param[in]  dq1: First dual quaternion
- * @param[in]  dq2: Second dual quaternion
- * @param[in]  tau [0, 1]
- * @param[out] return: Interpolated dual equation
- * note return dq1 when the error happened
- */
-DualQuaternion Sclerp(const DualQuaternion dq1, const DualQuaternion dq2, const double tau);
 
 }  // namespace libra

--- a/s2e-ff/src/Library/math/DualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/DualQuaternion.hpp
@@ -4,7 +4,7 @@
 
 namespace libra {
 
-class SkrewParameters {
+class ScrewParameters {
  public:
   Vector<3> axis_;
   double angle_rad_;
@@ -82,10 +82,10 @@ class DualQuaternion {
   Vector<3> InverseTransformVector(const Vector<3>& v) const;
 
   /**
-   * @fn Calculate skrew parameters from dual quaternion
-   * @param[out] return: Skrew parameters
+   * @fn Calculate screw parameters from dual quaternion
+   * @param[out] return: Screw parameters
    */
-  SkrewParameters CalcSkrewParameters() const;
+  ScrewParameters CalcScrewParameters() const;
 
   // Getter
   inline Quaternion GetRealPart() const { return q_real_; }

--- a/s2e-ff/src/Library/math/DualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/DualQuaternion.hpp
@@ -95,15 +95,6 @@ class DualQuaternion {
  protected:
   Quaternion q_real_;  //!< Real part Quaternion
   Quaternion q_dual_;  //!< Dual part Quaternion
-
-  /**
-   * @fn Screw Linear Interpolation without
-   * @param[in]  dq1: First dual quaternion
-   * @param[in]  dq2: Second dual quaternion
-   * @param[in]  tau: Interpolation coefficients [0, 1]
-   * @param[out] return: Interpolated dual quaternion
-   */
-  //  DualQuaternion Sclerp(const DualQuaternion dq1, const DualQuaternion dq2, const double tau);
 };
 
 // Operation functions

--- a/s2e-ff/src/Library/math/DualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/DualQuaternion.hpp
@@ -34,6 +34,11 @@ class DualQuaternion {
 
   // Operator for a single dual quaternon
   /**
+   * @fn Keeping scalar part of the rotation quaternion be positive
+   */
+  DualQuaternion Properization() const;
+
+  /**
    * @fn Calulate conjugated of the dual quaternion as dual number
    */
   DualQuaternion DualNumberConjugate() const;

--- a/s2e-ff/src/Library/math/DualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/DualQuaternion.hpp
@@ -41,6 +41,15 @@ class DualQuaternion {
    */
   DualQuaternion(const Quaternion q_rot, const Vector<3> v_translation);
 
+  /**
+   * @fn Constructor
+   * @brief Make from rotation quaternion and translation vector
+   *        Frame conversion sequence: Translation -> Rotation
+   * @param[in] q_rot: Quaternion for rotation. This quaternion is used after normalized in this function.
+   * @param[in] v_translation: Vector for translation
+   */
+  DualQuaternion(const Vector<3> v_translation, const Quaternion q_rot);
+
   // Operator for a single dual quaternon
   /**
    * @fn Normalize rotation quaternion
@@ -110,7 +119,8 @@ class DualQuaternion {
   inline Quaternion GetRealPart() const { return q_real_; }
   inline Quaternion GetDualPart() const { return q_dual_; }
   inline Quaternion GetRotationQuaternion() const { return q_real_; }
-  Vector<3> GetTranslationVector() const;
+  Vector<3> GetRotationFirstTranslationVector() const;
+  Vector<3> GetTranslationFirstTranslationVector() const;
 
  private:
   Quaternion q_real_;  //!< Real part Quaternion

--- a/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
@@ -63,14 +63,21 @@ Vector<3> RotationFirstDualQuaternion::GetTranslationVector() const {
 
 RotationFirstDualQuaternion Sclerp(const RotationFirstDualQuaternion dq1, const RotationFirstDualQuaternion dq2, const double tau) {
   if (tau < 0.0) return dq1;
-  if (tau > 1.0) return dq1;
+  if (tau > 1.0) return dq2;
 
   RotationFirstDualQuaternion dq1_inv = dq1.Inverse();
   RotationFirstDualQuaternion dq12 = dq1_inv * dq2;
+  dq12 = dq12.Properization();
 
   // Calc rotation angle and axis
   // TODO: make function in core's quaternion library
-  double theta = 2.0 * acos(dq12.GetRealPart()[3]);
+  double cos_part = dq12.GetRealPart()[3];
+  Vector<3> vector_part;
+  for (int i = 0; i < 3; i++) {
+    vector_part[i] = dq12.GetRealPart()[i];
+  }
+  double sin_part = norm(vector_part);
+  double theta = 2.0 * atan2(sin_part, cos_part);
   Vector<3> axis;
   if (theta < 0.0 + DBL_MIN) {
     // No rotation

--- a/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
@@ -37,9 +37,11 @@ void RotationFirstDualQuaternion::NormalizeRotationQauternion() {
 RotationFirstDualQuaternion RotationFirstDualQuaternion::Differential(const Vector<3>& omega, const Vector<3>& velocity) const {
   Quaternion q_omega(omega[0], omega[1], omega[2], 0.0);
   Quaternion q_velocity(velocity[0], velocity[1], velocity[2], 0.0);
+  Vector<3> v_translation = this->GetTranslationVector();
+  Quaternion q_translation(v_translation[0], v_translation[1], v_translation[2], 0.0);
 
   Quaternion q_real_out = 0.5 * q_omega * q_real_;
-  Quaternion q_dual_out = 0.5 * ((q_velocity * q_real_) + 0.5 * (q_velocity * q_omega * q_real_));
+  Quaternion q_dual_out = 0.5 * ((q_velocity * q_real_) + (q_translation * q_real_out));
 
   DualQuaternion dq_out(q_real_out, q_dual_out);
   return dq_out;

--- a/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
@@ -70,10 +70,10 @@ RotationFirstDualQuaternion Sclerp(const RotationFirstDualQuaternion dq1, const 
   dq12 = dq12.Properization();
 
   // Calc skrew params
-  SkrewParameters skrew = dq12.CalcSkrewParameters();
+  ScrewParameters screw = dq12.CalcScrewParameters();
 
   // When theta = 0
-  if (skrew.angle_rad_ < 0.0 + DBL_MIN) {
+  if (screw.angle_rad_ < 0.0 + DBL_MIN) {
     // Linear interpolation of translation
     Vector<3> v_out = tau * dq1.GetTranslationVector() + (1.0 - tau) * dq2.GetTranslationVector();
     RotationFirstDualQuaternion dq_out(dq1.GetRealPart(), v_out);
@@ -81,13 +81,13 @@ RotationFirstDualQuaternion Sclerp(const RotationFirstDualQuaternion dq1, const 
   }
 
   // Calc (dq1^-1 * dq2)^tau
-  Quaternion dq12_tau_real(skrew.axis_, tau * skrew.angle_rad_);
+  Quaternion dq12_tau_real(screw.axis_, tau * screw.angle_rad_);
   Quaternion dq12_tau_dual;
   for (int i = 0; i < 3; i++) {
     dq12_tau_dual[i] =
-        (0.5 * tau * skrew.pitch_) * cos(tau * skrew.angle_rad_ * 0.5) * skrew.axis_[i] + sin(tau * skrew.angle_rad_ * 0.5) * skrew.moment_[i];
+        (0.5 * tau * screw.pitch_) * cos(tau * screw.angle_rad_ * 0.5) * screw.axis_[i] + sin(tau * screw.angle_rad_ * 0.5) * screw.moment_[i];
   }
-  dq12_tau_dual[3] = -(0.5 * tau * skrew.pitch_) * sin(tau * skrew.angle_rad_ * 0.5);
+  dq12_tau_dual[3] = -(0.5 * tau * screw.pitch_) * sin(tau * screw.angle_rad_ * 0.5);
   DualQuaternion dq12_tau(dq12_tau_real, dq12_tau_dual);
 
   // Calc interpolated dual quaternion

--- a/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
@@ -78,35 +78,31 @@ RotationFirstDualQuaternion Sclerp(const RotationFirstDualQuaternion dq1, const 
   }
   double sin_part = norm(vector_part);
   double theta = 2.0 * atan2(sin_part, cos_part);
-  Vector<3> axis;
-
-  // Screw parameters
-  Vector<3> v_t = dq12.GetTranslationVector();
-  Vector<3> moment;
-  double pitch;
 
   // When theta = 0
   if (theta < 0.0 + DBL_MIN) {
-    // No rotation
-    axis = v_t;
-    moment = axis;
-    pitch = 0.0;
-  } else {
-    for (int i = 0; i < 3; i++) axis[i] = dq12.GetRealPart()[i];
-    pitch = dot(v_t, axis);
-    double cot = 1.0 / tan(theta * 0.5);
-    moment = 0.5 * (cross(v_t, axis) + cot * (v_t - pitch * axis));
+    // Linear interpolation of translation
+    Vector<3> v_out = tau * dq1.GetTranslationVector() + (1.0 - tau) * dq2.GetTranslationVector();
+    RotationFirstDualQuaternion dq_out(dq1.GetRealPart(), v_out);
+    return dq_out;
   }
+
+  // Screw parameters
+  Vector<3> axis;
+  for (int i = 0; i < 3; i++) axis[i] = dq12.GetRealPart()[i];
   normalize(axis);
+  Vector<3> v_t = dq12.GetTranslationVector();
+  double pitch = dot(v_t, axis);
+  double cot = 1.0 / tan(theta * 0.5);
+  Vector<3> moment = 0.5 * (cross(v_t, axis) + cot * (v_t - pitch * axis));
 
   // Calc (dq1^-1 * dq2)^tau
-
   Quaternion dq12_tau_real(axis, tau * theta);
   Quaternion dq12_tau_dual;
-  for (int i = 0; i < 3; i++){
+  for (int i = 0; i < 3; i++) {
     dq12_tau_dual[i] = (0.5 * tau * pitch) * cos(tau * theta * 0.5) * axis[i] + sin(tau * theta * 0.5) * moment[i];
-  } 
-  dq12_tau_dual[3] = - (0.5 * tau * pitch) * sin(tau * theta * 0.5);
+  }
+  dq12_tau_dual[3] = -(0.5 * tau * pitch) * sin(tau * theta * 0.5);
   DualQuaternion dq12_tau(dq12_tau_real, dq12_tau_dual);
   RotationFirstDualQuaternion dq12_tau_(dq12_tau);
 

--- a/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
@@ -100,14 +100,15 @@ RotationFirstDualQuaternion Sclerp(const RotationFirstDualQuaternion dq1, const 
   normalize(axis);
 
   // Calc (dq1^-1 * dq2)^tau
+
   Quaternion dq12_tau_real(axis, tau * theta);
   Quaternion dq12_tau_dual;
   for (int i = 0; i < 3; i++){
-    dq12_tau_dual[i] = cos(tau * theta * 0.5) * axis[i] + sin(tau * theta * 0.5) * moment[i];
+    dq12_tau_dual[i] = (0.5 * tau * pitch) * cos(tau * theta * 0.5) * axis[i] + sin(tau * theta * 0.5) * moment[i];
   } 
-  dq12_tau_dual[3] = -sin(tau * theta * 0.5);
-  dq12_tau_dual = (0.5 * tau * pitch) * dq12_tau_dual;
+  dq12_tau_dual[3] = - (0.5 * tau * pitch) * sin(tau * theta * 0.5);
   DualQuaternion dq12_tau(dq12_tau_real, dq12_tau_dual);
+  RotationFirstDualQuaternion dq12_tau_(dq12_tau);
 
   // Calc interpolated dual quaternion
   RotationFirstDualQuaternion dq_out = dq1 * dq12_tau;

--- a/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
@@ -1,0 +1,95 @@
+#include "RotationFirstDualQuaternion.hpp"
+
+#include <float.h>
+
+namespace libra {
+
+RotationFirstDualQuaternion::RotationFirstDualQuaternion() {}
+
+RotationFirstDualQuaternion::RotationFirstDualQuaternion(const DualQuaternion dq) : DualQuaternion(dq) {}
+
+RotationFirstDualQuaternion::RotationFirstDualQuaternion(const Quaternion q_rot, const Vector<3> v_translation) {
+  q_real_ = q_rot;
+  q_real_.normalize();
+
+  // TODO: Make vector * quaternion function in core's Quaternion class
+  Quaternion q_v(v_translation[0], v_translation[1], v_translation[2], 0.0);
+  q_dual_ = 0.5 * (q_v * q_real_);
+}
+
+RotationFirstDualQuaternion RotationFirstDualQuaternion::CalcNormalizedRotationQauternion() const {
+  Quaternion q_rot = q_real_;
+  Vector<3> v_translation = this->GetTranslationVector();
+  q_rot.normalize();
+
+  RotationFirstDualQuaternion dq_out(q_rot, v_translation);
+  return dq_out;
+}
+
+void RotationFirstDualQuaternion::NormalizeRotationQauternion() {
+  Vector<3> v_translation = this->GetTranslationVector();
+  q_real_.normalize();
+
+  RotationFirstDualQuaternion dq_out(q_real_, v_translation);
+  q_dual_ = dq_out.GetDualPart();
+}
+
+RotationFirstDualQuaternion RotationFirstDualQuaternion::Differential(const Vector<3>& omega, const Vector<3>& velocity) const {
+  Quaternion q_omega(omega[0], omega[1], omega[2], 0.0);
+  Quaternion q_velocity(velocity[0], velocity[1], velocity[2], 0.0);
+
+  Quaternion q_real_out = 0.5 * q_omega * q_real_;
+  Quaternion q_dual_out = 0.5 * ((q_velocity * q_real_) + 0.5 * (q_velocity * q_omega * q_real_));
+
+  DualQuaternion dq_out(q_real_out, q_dual_out);
+  return dq_out;
+}
+
+RotationFirstDualQuaternion RotationFirstDualQuaternion::Integrate(const Vector<3>& omega, const Vector<3>& velocity, const double dt) const {
+  RotationFirstDualQuaternion diff_dq = this->Differential(omega, velocity);
+  RotationFirstDualQuaternion dq_out = (*this) + dt * diff_dq;
+  dq_out.NormalizeRotationQauternion();
+  return dq_out;
+}
+
+Vector<3> RotationFirstDualQuaternion::GetTranslationVector() const {
+  Quaternion q_out = 2.0 * q_dual_ * q_real_.conjugate();
+  Vector<3> v_out;
+  for (int i = 0; i < 3; i++) v_out[i] = q_out[i];
+  return v_out;
+}
+
+RotationFirstDualQuaternion Sclerp(const RotationFirstDualQuaternion dq1, const RotationFirstDualQuaternion dq2, const double tau) {
+  if (tau < 0.0) return dq1;
+  if (tau > 1.0) return dq1;
+
+  RotationFirstDualQuaternion dq1_inv = dq1.Inverse();
+  RotationFirstDualQuaternion dq12 = dq1_inv * dq2;
+
+  // Calc rotation angle and axis
+  // TODO: make function in core's quaternion library
+  double theta = 2.0 * acos(dq12.GetRealPart()[3]);
+  Vector<3> axis;
+  if (theta < 0.0 + DBL_MIN) {
+    // No rotation
+    axis = dq12.GetTranslationVector();
+  } else {
+    for (int i = 0; i < 3; i++) axis[i] = dq12.GetRealPart()[i];
+  }
+  normalize(axis);
+
+  // Calc (dq1^-1 * dq2)^tau
+  double d = dot(dq12.GetTranslationVector(), axis);
+  Quaternion dq12_tau_real(axis, tau * theta);
+  Quaternion dq12_tau_dual;
+  for (int i = 0; i < 3; i++) dq12_tau_dual[i] = cos(tau * theta * 0.5) * axis[i];
+  dq12_tau_dual[3] = -sin(tau * theta * 0.5);
+  dq12_tau_dual = (0.5 * tau * d) * dq12_tau_dual;
+  DualQuaternion dq12_tau(dq12_tau_real, dq12_tau_dual);
+
+  // Calc interpolated dual quaternion
+  RotationFirstDualQuaternion dq_out = dq1 * dq12_tau;
+  return dq_out;
+}
+
+}  // namespace libra

--- a/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/RotationFirstDualQuaternion.cpp
@@ -69,26 +69,16 @@ RotationFirstDualQuaternion Sclerp(const RotationFirstDualQuaternion dq1, const 
   RotationFirstDualQuaternion dq12 = dq1_inv * dq2;
   dq12 = dq12.Properization();
 
-  // Calc skrew params
-  ScrewParameters screw = dq12.CalcScrewParameters();
+  // Calc power of dq12
+  DualQuaternion dq12_tau = dq12.Power(tau);
 
   // When theta = 0
-  if (screw.angle_rad_ < 0.0 + DBL_MIN) {
+  if ((1.0 - fabs(dq12_tau.GetRealPart()[3])) < 0.0 + DBL_MIN) {
     // Linear interpolation of translation
     Vector<3> v_out = tau * dq1.GetTranslationVector() + (1.0 - tau) * dq2.GetTranslationVector();
     RotationFirstDualQuaternion dq_out(dq1.GetRealPart(), v_out);
     return dq_out;
   }
-
-  // Calc (dq1^-1 * dq2)^tau
-  Quaternion dq12_tau_real(screw.axis_, tau * screw.angle_rad_);
-  Quaternion dq12_tau_dual;
-  for (int i = 0; i < 3; i++) {
-    dq12_tau_dual[i] =
-        (0.5 * tau * screw.pitch_) * cos(tau * screw.angle_rad_ * 0.5) * screw.axis_[i] + sin(tau * screw.angle_rad_ * 0.5) * screw.moment_[i];
-  }
-  dq12_tau_dual[3] = -(0.5 * tau * screw.pitch_) * sin(tau * screw.angle_rad_ * 0.5);
-  DualQuaternion dq12_tau(dq12_tau_real, dq12_tau_dual);
 
   // Calc interpolated dual quaternion
   RotationFirstDualQuaternion dq_out = dq1 * dq12_tau;

--- a/s2e-ff/src/Library/math/RotationFirstDualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/RotationFirstDualQuaternion.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "DualQuaternion.hpp"
+
+namespace libra {
+
+/**
+ * @class RotationFirstDualQuaternion
+ * @brief Frame conversion sequence: Rotation -> Translation
+ */
+class RotationFirstDualQuaternion : public DualQuaternion {
+ public:
+  // Constructors
+  /**
+   * @fn Default Constructor
+   * @brief make unit dual quaternion without any conversion
+   */
+  RotationFirstDualQuaternion();
+
+  /**
+   * @fn Constructor
+   * @brief Copy dual quaternion
+   */
+  RotationFirstDualQuaternion(const DualQuaternion dq);
+
+  /**
+   * @fn Constructor
+   * @brief Make from rotation quaternion and translation vector
+   *        Frame conversion sequence: Rotation -> Translation
+   * @param[in] q_rot: Quaternion for rotation. This quaternion is used after normalized in this function.
+   * @param[in] v_translation: Vector for translation
+   */
+  RotationFirstDualQuaternion(const Quaternion q_rot, const Vector<3> v_translation);
+
+  // Operator for a single dual quaternon
+  /**
+   * @fn Normalize rotation quaternion
+   * @brief This function doesn't change the original DualQuaternion value
+   */
+  RotationFirstDualQuaternion CalcNormalizedRotationQauternion() const;
+
+  /**
+   * @fn Normalize rotation quaternion
+   * @brief This function changes the original DualQuaternion value
+   */
+  void NormalizeRotationQauternion();
+
+  /**
+   * @fn Differential equation of dual quaternion
+   * @param[in]  omega: Angular velocity [rad/s]
+   * @param[in]  velocity: Velocity [-]
+   * @param[out] return: Differential of dual equation
+   */
+  RotationFirstDualQuaternion Differential(const Vector<3>& omega, const Vector<3>& velocity) const;
+
+  /**
+   * @fn Differential equation of dual quaternion
+   * @param[in]  omega: Angular velocity [rad/s]
+   * @param[in]  velocity: Velocity [-]
+   * @param[in]  dt: Differential time [s]
+   * @param[out] return: Integrated dual equation
+   */
+  RotationFirstDualQuaternion Integrate(const Vector<3>& omega, const Vector<3>& velocity, const double dt) const;
+
+  // Getter
+  Vector<3> GetTranslationVector() const;
+
+ private:
+};
+
+// Operation functions
+/**
+ * @fn Screw Linear Interpolation
+ * @param[in]  dq1: First dual quaternion
+ * @param[in]  dq2: Second dual quaternion
+ * @param[in]  tau [0, 1]
+ * @param[out] return: Interpolated dual equation
+ * note return dq1 when the error happened
+ */
+RotationFirstDualQuaternion Sclerp(const RotationFirstDualQuaternion dq1, const RotationFirstDualQuaternion dq2, const double tau);
+
+}  // namespace libra

--- a/s2e-ff/src/Library/math/RotationFirstDualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/RotationFirstDualQuaternion.hpp
@@ -73,9 +73,8 @@ class RotationFirstDualQuaternion : public DualQuaternion {
  * @fn Screw Linear Interpolation
  * @param[in]  dq1: First dual quaternion
  * @param[in]  dq2: Second dual quaternion
- * @param[in]  tau [0, 1]
- * @param[out] return: Interpolated dual equation
- * note return dq1 when the error happened
+ * @param[in]  tau: Interpolation coefficients [0, 1]
+ * @param[out] return: Interpolated dual quaternion
  */
 RotationFirstDualQuaternion Sclerp(const RotationFirstDualQuaternion dq1, const RotationFirstDualQuaternion dq2, const double tau);
 

--- a/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
@@ -83,9 +83,11 @@ TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, 
   // Calc (dq1^-1 * dq2)^tau
   Quaternion dq12_tau_real(skrew.axis_, tau * skrew.angle_rad_);
   Quaternion dq12_tau_dual;
-  for (int i = 0; i < 3; i++) dq12_tau_dual[i] = cos(tau * skrew.angle_rad_ * 0.5) * skrew.axis_[i];
-  dq12_tau_dual[3] = -sin(tau * skrew.angle_rad_ * 0.5);
-  dq12_tau_dual = (0.5 * tau * skrew.pitch_) * dq12_tau_dual;
+  for (int i = 0; i < 3; i++) {
+    dq12_tau_dual[i] =
+        (0.5 * tau * skrew.pitch_) * cos(tau * skrew.angle_rad_ * 0.5) * skrew.axis_[i] + sin(tau * skrew.angle_rad_ * 0.5) * skrew.moment_[i];
+  }
+  dq12_tau_dual[3] = -(0.5 * tau * skrew.pitch_) * sin(tau * skrew.angle_rad_ * 0.5);
   DualQuaternion dq12_tau(dq12_tau_real, dq12_tau_dual);
 
   // Calc interpolated dual quaternion

--- a/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
@@ -61,7 +61,6 @@ Vector<3> TranslationFirstDualQuaternion::GetTranslationVector() const {
   return v_out;
 }
 
-/*
 TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, const TranslationFirstDualQuaternion dq2, const double tau) {
   if (tau < 0.0) return dq1;
   if (tau > 1.0) return dq2;
@@ -78,6 +77,16 @@ TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, 
   }
   double sin_part = norm(vector_part);
   double theta = 2.0 * atan2(sin_part, cos_part);
+
+  // When theta = 0
+  if (theta < 0.0 + DBL_MIN) {
+    // Linear interpolation of translation
+    Vector<3> v_out = tau * dq1.GetTranslationVector() + (1.0 - tau) * dq2.GetTranslationVector();
+    TranslationFirstDualQuaternion dq_out(v_out, dq1.GetRealPart());
+    return dq_out;
+  }
+
+  // Screw parameters
   Vector<3> axis;
   if (theta < 0.0 + DBL_MIN) {
     // No rotation
@@ -100,5 +109,5 @@ TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, 
   TranslationFirstDualQuaternion dq_out = dq1 * dq12_tau;
   return dq_out;
 }
-*/
+
 }  // namespace libra

--- a/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
@@ -1,0 +1,97 @@
+#include "TranslationFirstDualQuaternion.hpp"
+
+#include <float.h>
+
+namespace libra {
+
+TranslationFirstDualQuaternion::TranslationFirstDualQuaternion() {}
+
+TranslationFirstDualQuaternion::TranslationFirstDualQuaternion(const DualQuaternion dq) : DualQuaternion(dq) {}
+
+TranslationFirstDualQuaternion::TranslationFirstDualQuaternion(const Vector<3> v_translation, const Quaternion q_rot) {
+  q_real_ = q_rot;
+  q_real_.normalize();
+
+  // TODO: Make vector * quaternion function in core's Quaternion class
+  Quaternion q_v(v_translation[0], v_translation[1], v_translation[2], 0.0);
+  q_dual_ = 0.5 * (q_real_ * q_v);
+}
+
+TranslationFirstDualQuaternion TranslationFirstDualQuaternion::CalcNormalizedRotationQauternion() const {
+  Quaternion q_rot = q_real_;
+  Vector<3> v_translation = this->GetTranslationVector();
+  q_rot.normalize();
+
+  TranslationFirstDualQuaternion dq_out(v_translation, q_rot);
+  return dq_out;
+}
+
+void TranslationFirstDualQuaternion::NormalizeRotationQauternion() {
+  Vector<3> v_translation = this->GetTranslationVector();
+  q_real_.normalize();
+
+  TranslationFirstDualQuaternion dq_out(v_translation, q_real_);
+  q_dual_ = dq_out.GetDualPart();
+}
+
+TranslationFirstDualQuaternion TranslationFirstDualQuaternion::Differential(const Vector<3>& omega, const Vector<3>& velocity) const {
+  Quaternion q_omega(omega[0], omega[1], omega[2], 0.0);
+  Quaternion q_velocity(velocity[0], velocity[1], velocity[2], 0.0);
+  Vector<3> v_translation = this->GetTranslationVector();
+  Quaternion q_translation(v_translation[0], v_translation[1], v_translation[2], 0.0);
+
+  Quaternion q_real_out = 0.5 * q_omega * q_real_;
+  Quaternion q_dual_out = 0.5 * ((q_real_out * q_translation) + (q_real_ * q_velocity));
+
+  DualQuaternion dq_out(q_real_out, q_dual_out);
+  return dq_out;
+}
+
+TranslationFirstDualQuaternion TranslationFirstDualQuaternion::Integrate(const Vector<3>& omega, const Vector<3>& velocity, const double dt) const {
+  TranslationFirstDualQuaternion diff_dq = this->Differential(omega, velocity);
+  TranslationFirstDualQuaternion dq_out = (*this) + dt * diff_dq;
+  dq_out.NormalizeRotationQauternion();
+  return dq_out;
+}
+
+Vector<3> TranslationFirstDualQuaternion::GetTranslationVector() const {
+  Quaternion q_out = 2.0 * q_real_.conjugate() * q_dual_;
+  Vector<3> v_out;
+  for (int i = 0; i < 3; i++) v_out[i] = q_out[i];
+  return v_out;
+}
+
+TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, const TranslationFirstDualQuaternion dq2, const double tau) {
+  if (tau < 0.0) return dq1;
+  if (tau > 1.0) return dq1;
+
+  TranslationFirstDualQuaternion dq1_inv = dq1.Inverse();
+  TranslationFirstDualQuaternion dq12 = dq1_inv * dq2;
+
+  // Calc rotation angle and axis
+  // TODO: make function in core's quaternion library
+  double theta = 2.0 * acos(dq12.GetRealPart()[3]);
+  Vector<3> axis;
+  if (theta < 0.0 + DBL_MIN) {
+    // No rotation
+    axis = dq12.GetTranslationVector();
+  } else {
+    for (int i = 0; i < 3; i++) axis[i] = dq12.GetRealPart()[i];
+  }
+  normalize(axis);
+
+  // Calc (dq1^-1 * dq2)^tau
+  double d = dot(dq12.GetTranslationVector(), axis);
+  Quaternion dq12_tau_real(axis, tau * theta);
+  Quaternion dq12_tau_dual;
+  for (int i = 0; i < 3; i++) dq12_tau_dual[i] = cos(tau * theta * 0.5) * axis[i];
+  dq12_tau_dual[3] = -sin(tau * theta * 0.5);
+  dq12_tau_dual = (0.5 * tau * d) * dq12_tau_dual;
+  DualQuaternion dq12_tau(dq12_tau_real, dq12_tau_dual);
+
+  // Calc interpolated dual quaternion
+  TranslationFirstDualQuaternion dq_out = dq1 * dq12_tau;
+  return dq_out;
+}
+
+}  // namespace libra

--- a/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
@@ -63,14 +63,20 @@ Vector<3> TranslationFirstDualQuaternion::GetTranslationVector() const {
 
 TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, const TranslationFirstDualQuaternion dq2, const double tau) {
   if (tau < 0.0) return dq1;
-  if (tau > 1.0) return dq1;
+  if (tau > 1.0) return dq2;
 
   TranslationFirstDualQuaternion dq1_inv = dq1.Inverse();
   TranslationFirstDualQuaternion dq12 = dq1_inv * dq2;
 
   // Calc rotation angle and axis
   // TODO: make function in core's quaternion library
-  double theta = 2.0 * acos(dq12.GetRealPart()[3]);
+  double cos_part = dq12.GetRealPart()[3];
+  Vector<3> vector_part;
+  for (int i = 0; i < 3; i++) {
+    vector_part[i] = dq12.GetRealPart()[i];
+  }
+  double sin_part = norm(vector_part);
+  double theta = 2.0 * atan2(sin_part, cos_part);
   Vector<3> axis;
   if (theta < 0.0 + DBL_MIN) {
     // No rotation

--- a/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
@@ -67,42 +67,25 @@ TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, 
 
   TranslationFirstDualQuaternion dq1_inv = dq1.Inverse();
   TranslationFirstDualQuaternion dq12 = dq1_inv * dq2;
+  dq12 = dq12.Properization();
 
-  // Calc rotation angle and axis
-  // TODO: make function in core's quaternion library
-  double cos_part = dq12.GetRealPart()[3];
-  Vector<3> vector_part;
-  for (int i = 0; i < 3; i++) {
-    vector_part[i] = dq12.GetRealPart()[i];
-  }
-  double sin_part = norm(vector_part);
-  double theta = 2.0 * atan2(sin_part, cos_part);
+  // Calc skrew params
+  SkrewParameters skrew = dq12.CalcSkrewParameters();
 
   // When theta = 0
-  if (theta < 0.0 + DBL_MIN) {
+  if (skrew.angle_rad_ < 0.0 + DBL_MIN) {
     // Linear interpolation of translation
     Vector<3> v_out = tau * dq1.GetTranslationVector() + (1.0 - tau) * dq2.GetTranslationVector();
     TranslationFirstDualQuaternion dq_out(v_out, dq1.GetRealPart());
     return dq_out;
   }
 
-  // Screw parameters
-  Vector<3> axis;
-  if (theta < 0.0 + DBL_MIN) {
-    // No rotation
-    axis = dq12.GetTranslationVector();
-  } else {
-    for (int i = 0; i < 3; i++) axis[i] = dq12.GetRealPart()[i];
-  }
-  normalize(axis);
-
   // Calc (dq1^-1 * dq2)^tau
-  double d = dot(dq12.GetTranslationVector(), axis);
-  Quaternion dq12_tau_real(axis, tau * theta);
+  Quaternion dq12_tau_real(skrew.axis_, tau * skrew.angle_rad_);
   Quaternion dq12_tau_dual;
-  for (int i = 0; i < 3; i++) dq12_tau_dual[i] = cos(tau * theta * 0.5) * axis[i];
-  dq12_tau_dual[3] = -sin(tau * theta * 0.5);
-  dq12_tau_dual = (0.5 * tau * d) * dq12_tau_dual;
+  for (int i = 0; i < 3; i++) dq12_tau_dual[i] = cos(tau * skrew.angle_rad_ * 0.5) * skrew.axis_[i];
+  dq12_tau_dual[3] = -sin(tau * skrew.angle_rad_ * 0.5);
+  dq12_tau_dual = (0.5 * tau * skrew.pitch_) * dq12_tau_dual;
   DualQuaternion dq12_tau(dq12_tau_real, dq12_tau_dual);
 
   // Calc interpolated dual quaternion

--- a/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
@@ -70,10 +70,10 @@ TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, 
   dq12 = dq12.Properization();
 
   // Calc skrew params
-  SkrewParameters skrew = dq12.CalcSkrewParameters();
+  ScrewParameters screw = dq12.CalcScrewParameters();
 
   // When theta = 0
-  if (skrew.angle_rad_ < 0.0 + DBL_MIN) {
+  if (screw.angle_rad_ < 0.0 + DBL_MIN) {
     // Linear interpolation of translation
     Vector<3> v_out = tau * dq1.GetTranslationVector() + (1.0 - tau) * dq2.GetTranslationVector();
     TranslationFirstDualQuaternion dq_out(v_out, dq1.GetRealPart());
@@ -81,13 +81,13 @@ TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, 
   }
 
   // Calc (dq1^-1 * dq2)^tau
-  Quaternion dq12_tau_real(skrew.axis_, tau * skrew.angle_rad_);
+  Quaternion dq12_tau_real(screw.axis_, tau * screw.angle_rad_);
   Quaternion dq12_tau_dual;
   for (int i = 0; i < 3; i++) {
     dq12_tau_dual[i] =
-        (0.5 * tau * skrew.pitch_) * cos(tau * skrew.angle_rad_ * 0.5) * skrew.axis_[i] + sin(tau * skrew.angle_rad_ * 0.5) * skrew.moment_[i];
+        (0.5 * tau * screw.pitch_) * cos(tau * screw.angle_rad_ * 0.5) * screw.axis_[i] + sin(tau * screw.angle_rad_ * 0.5) * screw.moment_[i];
   }
-  dq12_tau_dual[3] = -(0.5 * tau * skrew.pitch_) * sin(tau * skrew.angle_rad_ * 0.5);
+  dq12_tau_dual[3] = -(0.5 * tau * screw.pitch_) * sin(tau * screw.angle_rad_ * 0.5);
   DualQuaternion dq12_tau(dq12_tau_real, dq12_tau_dual);
 
   // Calc interpolated dual quaternion

--- a/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.cpp
@@ -61,6 +61,7 @@ Vector<3> TranslationFirstDualQuaternion::GetTranslationVector() const {
   return v_out;
 }
 
+/*
 TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, const TranslationFirstDualQuaternion dq2, const double tau) {
   if (tau < 0.0) return dq1;
   if (tau > 1.0) return dq2;
@@ -99,5 +100,5 @@ TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, 
   TranslationFirstDualQuaternion dq_out = dq1 * dq12_tau;
   return dq_out;
 }
-
+*/
 }  // namespace libra

--- a/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "DualQuaternion.hpp"
+
+namespace libra {
+
+/**
+ * @class TranslationFirstDualQuaternion
+ * @brief Frame conversion sequence: Translation -> Rotation
+ */
+class TranslationFirstDualQuaternion : public DualQuaternion {
+ public:
+  // Constructors
+  // Constructors
+  /**
+   * @fn Default Constructor
+   * @brief make unit dual quaternion without any conversion
+   */
+  TranslationFirstDualQuaternion();
+
+  /**
+   * @fn Constructor
+   * @brief Copy dual quaternion
+   */
+  TranslationFirstDualQuaternion(const DualQuaternion dq);
+
+  /**
+   * @fn Constructor
+   * @brief Make from rotation quaternion and translation vector
+   *        Frame conversion sequence: Rotation -> Translation
+   * @param[in] v_translation: Vector for translation
+   * @param[in] q_rot: Quaternion for rotation. This quaternion is used after normalized in this function.
+   */
+  TranslationFirstDualQuaternion(const Vector<3> v_translation, const Quaternion q_rot);
+
+  // Operator for a single dual quaternon
+  /**
+   * @fn Normalize rotation quaternion
+   * @brief This function doesn't change the original DualQuaternion value
+   */
+  TranslationFirstDualQuaternion CalcNormalizedRotationQauternion() const;
+
+  /**
+   * @fn Normalize rotation quaternion
+   * @brief This function changes the original DualQuaternion value
+   */
+  void NormalizeRotationQauternion();
+
+  /**
+   * @fn Differential equation of dual quaternion
+   * @param[in]  omega: Angular velocity [rad/s]
+   * @param[in]  velocity: Velocity [-]
+   * @param[out] return: Differential of dual equation
+   */
+  TranslationFirstDualQuaternion Differential(const Vector<3>& omega, const Vector<3>& velocity) const;
+
+  /**
+   * @fn Differential equation of dual quaternion
+   * @param[in]  omega: Angular velocity [rad/s]
+   * @param[in]  velocity: Velocity [-]
+   * @param[in]  dt: Differential time [s]
+   * @param[out] return: Integrated dual equation
+   */
+  TranslationFirstDualQuaternion Integrate(const Vector<3>& omega, const Vector<3>& velocity, const double dt) const;
+
+  // Getter
+  Vector<3> GetTranslationVector() const;
+
+ private:
+};
+
+// Operation functions
+/**
+ * @fn Screw Linear Interpolation
+ * @param[in]  dq1: First dual quaternion
+ * @param[in]  dq2: Second dual quaternion
+ * @param[in]  tau [0, 1]
+ * @param[out] return: Interpolated dual equation
+ * note return dq1 when the error happened
+ */
+TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, const TranslationFirstDualQuaternion dq2, const double tau);
+
+}  // namespace libra

--- a/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.hpp
@@ -11,7 +11,6 @@ namespace libra {
 class TranslationFirstDualQuaternion : public DualQuaternion {
  public:
   // Constructors
-  // Constructors
   /**
    * @fn Default Constructor
    * @brief make unit dual quaternion without any conversion
@@ -78,6 +77,6 @@ class TranslationFirstDualQuaternion : public DualQuaternion {
  * @param[out] return: Interpolated dual equation
  * note return dq1 when the error happened
  */
-//TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, const TranslationFirstDualQuaternion dq2, const double tau);
+TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, const TranslationFirstDualQuaternion dq2, const double tau);
 
 }  // namespace libra

--- a/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.hpp
@@ -78,6 +78,6 @@ class TranslationFirstDualQuaternion : public DualQuaternion {
  * @param[out] return: Interpolated dual equation
  * note return dq1 when the error happened
  */
-TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, const TranslationFirstDualQuaternion dq2, const double tau);
+//TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, const TranslationFirstDualQuaternion dq2, const double tau);
 
 }  // namespace libra

--- a/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.hpp
+++ b/s2e-ff/src/Library/math/TranslationFirstDualQuaternion.hpp
@@ -73,9 +73,8 @@ class TranslationFirstDualQuaternion : public DualQuaternion {
  * @fn Screw Linear Interpolation
  * @param[in]  dq1: First dual quaternion
  * @param[in]  dq2: Second dual quaternion
- * @param[in]  tau [0, 1]
- * @param[out] return: Interpolated dual equation
- * note return dq1 when the error happened
+ * @param[in]  tau: Interpolation coefficients [0, 1]
+ * @param[out] return: Interpolated dual quaternion
  */
 TranslationFirstDualQuaternion Sclerp(const TranslationFirstDualQuaternion dq1, const TranslationFirstDualQuaternion dq2, const double tau);
 

--- a/s2e-ff/test/TestDualQuaternion.cpp
+++ b/s2e-ff/test/TestDualQuaternion.cpp
@@ -98,14 +98,11 @@ TEST(DualQuaternion, Inverse) {
   EXPECT_DOUBLE_EQ(-0.5, dq_out.GetDualPart()[2]);
   EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[3]);
 }
-/*
+
 TEST(DualQuaternion, TransformVectorXrot) {
-  libra::Quaternion q_rot(1.0, 0.0, 0.0, 1.0);  // 90deg rotation around X axis
-  libra::Vector<3> v_translation;
-  v_translation[0] = 0.0;
-  v_translation[1] = 0.0;
-  v_translation[2] = 1.0;
-  libra::DualQuaternion dq(q_rot, v_translation);
+  libra::Quaternion q_real(0.707106, 0.0, 0.0, 0.707106);  // 90deg rotation around X axis
+  libra::Quaternion q_dual(0.0, 0.707106, 0.707106, 0.0);  // 2 step move to Z axis
+  libra::DualQuaternion dq(q_real, q_dual);
 
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
@@ -114,24 +111,21 @@ TEST(DualQuaternion, TransformVectorXrot) {
 
   libra::Vector<3> v_out = dq.TransformVector(v_in);
 
-  EXPECT_DOUBLE_EQ(1.0, v_out[0]);
-  EXPECT_DOUBLE_EQ(0.0, v_out[1]);
-  EXPECT_DOUBLE_EQ(1.0, v_out[2]);
+  EXPECT_NEAR(1.0, v_out[0], 1e-4);
+  EXPECT_NEAR(0.0, v_out[1], 1e-4);
+  EXPECT_NEAR(2.0, v_out[2], 1e-4);
 
   libra::Vector<3> v_out_inverse = dq.InverseTransformVector(v_out);
 
-  EXPECT_NEAR(v_in[0], v_out_inverse[0], 1e-9);
-  EXPECT_NEAR(v_in[1], v_out_inverse[1], 1e-9);
-  EXPECT_NEAR(v_in[2], v_out_inverse[2], 1e-9);
+  EXPECT_NEAR(v_in[0], v_out_inverse[0], 1e-4);
+  EXPECT_NEAR(v_in[1], v_out_inverse[1], 1e-4);
+  EXPECT_NEAR(v_in[2], v_out_inverse[2], 1e-4);
 }
 
 TEST(DualQuaternion, TransformVectorYrot) {
-  libra::Quaternion q_rot(0.0, 1.0, 0.0, 1.0);  // 90deg rotation around Y axis
-  libra::Vector<3> v_translation;
-  v_translation[0] = 0.0;
-  v_translation[1] = 0.0;
-  v_translation[2] = 2.0;
-  libra::DualQuaternion dq(q_rot, v_translation);
+  libra::Quaternion q_real(0.0, 0.707106, 0.0, 0.707106);   // 90deg rotation around Y axis
+  libra::Quaternion q_dual(-0.707106, 0.0, 0.707106, 0.0);  // 2 step move to Z axis
+  libra::DualQuaternion dq(q_real, q_dual);
 
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
@@ -140,24 +134,21 @@ TEST(DualQuaternion, TransformVectorYrot) {
 
   libra::Vector<3> v_out = dq.TransformVector(v_in);
 
-  EXPECT_DOUBLE_EQ(0.0, v_out[0]);
-  EXPECT_DOUBLE_EQ(0.0, v_out[1]);
-  EXPECT_DOUBLE_EQ(1.0, v_out[2]);
+  EXPECT_NEAR(0.0, v_out[0], 1e-4);
+  EXPECT_NEAR(0.0, v_out[1], 1e-4);
+  EXPECT_NEAR(1.0, v_out[2], 1e-4);
 
   libra::Vector<3> v_out_inverse = dq.InverseTransformVector(v_out);
 
-  EXPECT_NEAR(v_in[0], v_out_inverse[0], 1e-9);
-  EXPECT_NEAR(v_in[1], v_out_inverse[1], 1e-9);
-  EXPECT_NEAR(v_in[2], v_out_inverse[2], 1e-9);
+  EXPECT_NEAR(v_in[0], v_out_inverse[0], 1e-4);
+  EXPECT_NEAR(v_in[1], v_out_inverse[1], 1e-4);
+  EXPECT_NEAR(v_in[2], v_out_inverse[2], 1e-4);
 }
 
 TEST(DualQuaternion, TransformVectorZrot) {
-  libra::Quaternion q_rot(0.0, 0.0, 1.0, 1.0);  // 90deg rotation around Z axis
-  libra::Vector<3> v_translation;
-  v_translation[0] = 0.0;
-  v_translation[1] = 0.0;
-  v_translation[2] = 1.0;
-  libra::DualQuaternion dq(q_rot, v_translation);
+  libra::Quaternion q_real(0.0, 0.0, 0.707106, 0.707106);   // 90deg rotation around Z axis
+  libra::Quaternion q_dual(0.0, 0.0, 0.707106, -0.707106);  // 2 step move to Z axis
+  libra::DualQuaternion dq(q_real, q_dual);
 
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
@@ -166,24 +157,21 @@ TEST(DualQuaternion, TransformVectorZrot) {
 
   libra::Vector<3> v_out = dq.TransformVector(v_in);
 
-  EXPECT_DOUBLE_EQ(0.0, v_out[0]);
-  EXPECT_DOUBLE_EQ(1.0, v_out[1]);
-  EXPECT_DOUBLE_EQ(1.0, v_out[2]);
+  EXPECT_NEAR(0.0, v_out[0], 1e-4);
+  EXPECT_NEAR(1.0, v_out[1], 1e-4);
+  EXPECT_NEAR(2.0, v_out[2], 1e-4);
 
   libra::Vector<3> v_out_inverse = dq.InverseTransformVector(v_out);
 
-  EXPECT_NEAR(v_in[0], v_out_inverse[0], 1e-9);
-  EXPECT_NEAR(v_in[1], v_out_inverse[1], 1e-9);
-  EXPECT_NEAR(v_in[2], v_out_inverse[2], 1e-9);
+  EXPECT_NEAR(v_in[0], v_out_inverse[0], 1e-4);
+  EXPECT_NEAR(v_in[1], v_out_inverse[1], 1e-4);
+  EXPECT_NEAR(v_in[2], v_out_inverse[2], 1e-4);
 }
 
 TEST(DualQuaternion, TransformVectorAllAxes) {
-  libra::Quaternion q_rot(1.0, 1.0, 1.0, 1.0);
-  libra::Vector<3> v_translation;
-  v_translation[0] = 0.0;
-  v_translation[1] = 0.0;
-  v_translation[2] = -1.0;
-  libra::DualQuaternion dq(q_rot, v_translation);
+  libra::Quaternion q_real(0.5, 0.5, 0.5, 0.5);        // all axis rotation
+  libra::Quaternion q_dual(-0.25, 0.25, 0.25, -0.25);  // 1 step move to Z axis
+  libra::DualQuaternion dq(q_real, q_dual);
 
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
@@ -192,17 +180,16 @@ TEST(DualQuaternion, TransformVectorAllAxes) {
 
   libra::Vector<3> v_out = dq.TransformVector(v_in);
 
-  EXPECT_DOUBLE_EQ(0.0, v_out[0]);
-  EXPECT_DOUBLE_EQ(1.0, v_out[1]);
-  EXPECT_DOUBLE_EQ(-1.0, v_out[2]);
+  EXPECT_NEAR(0.0, v_out[0], 1e-4);
+  EXPECT_NEAR(1.0, v_out[1], 1e-4);
+  EXPECT_NEAR(1.0, v_out[2], 1e-4);
 
   libra::Vector<3> v_out_inverse = dq.InverseTransformVector(v_out);
 
-  EXPECT_NEAR(v_in[0], v_out_inverse[0], 1e-9);
-  EXPECT_NEAR(v_in[1], v_out_inverse[1], 1e-9);
-  EXPECT_NEAR(v_in[2], v_out_inverse[2], 1e-9);
+  EXPECT_NEAR(v_in[0], v_out_inverse[0], 1e-4);
+  EXPECT_NEAR(v_in[1], v_out_inverse[1], 1e-4);
+  EXPECT_NEAR(v_in[2], v_out_inverse[2], 1e-4);
 }
-*/
 
 TEST(DualQuaternion, CalcScrewParametersNoRotation) {
   // No rotation error

--- a/s2e-ff/test/TestDualQuaternion.cpp
+++ b/s2e-ff/test/TestDualQuaternion.cpp
@@ -16,75 +16,88 @@ TEST(DualQuaternion, DefaultConstructor) {
 }
 
 TEST(DualQuaternion, ConstructorFromTwoQuaternion) {
-  libra::Quaternion q_real(0, 0, 0, 1);
-  libra::Quaternion q_dual(0, 0, 0, 2);
+  libra::Quaternion q_real(0.5, 0.5, 0.5, 0.5);
+  libra::Quaternion q_dual(0.1, 0.2, 0.3, 2);
   libra::DualQuaternion dq(q_real, q_dual);
 
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[2]);
-  EXPECT_DOUBLE_EQ(1.0, dq.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.5, dq.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.5, dq.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.5, dq.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(0.5, dq.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.1, dq.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(0.2, dq.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(0.3, dq.GetDualPart()[2]);
   EXPECT_DOUBLE_EQ(2.0, dq.GetDualPart()[3]);
 }
 
 TEST(DualQuaternion, ConstructorFromEightValue) {
-  libra::DualQuaternion dq(0, 0, 0, 2, 0, 0, 0, 1);
+  libra::DualQuaternion dq(0.5, 0.5, 0.5, 0.5, -0.1, -0.2, -0.3, -2);
 
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[2]);
-  EXPECT_DOUBLE_EQ(2.0, dq.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[2]);
-  EXPECT_DOUBLE_EQ(1.0, dq.GetDualPart()[3]);
+  EXPECT_DOUBLE_EQ(0.5, dq.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.5, dq.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.5, dq.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(0.5, dq.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(-0.1, dq.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(-0.2, dq.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(-0.3, dq.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(-2.0, dq.GetDualPart()[3]);
 }
 
 TEST(DualQuaternion, DualNumberConjugate) {
-  libra::DualQuaternion dq(0, 0, 0, 1, 0, 0, 0, 1);
+  libra::DualQuaternion dq(0.5, 0.5, 0.5, 0.5, -0.1, -0.2, -0.3, -2);
   libra::DualQuaternion dq_out = dq.DualNumberConjugate();
 
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[2]);
-  EXPECT_DOUBLE_EQ(1.0, dq_out.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[2]);
-  EXPECT_DOUBLE_EQ(-1.0, dq_out.GetDualPart()[3]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.1, dq_out.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(0.2, dq_out.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(0.3, dq_out.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(2.0, dq_out.GetDualPart()[3]);
 }
 
 TEST(DualQuaternion, QuaternionConjugate) {
-  libra::DualQuaternion dq(0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5);
+  libra::DualQuaternion dq(0.5, 0.5, -0.5, 0.5, -0.5, 0.5, 0.5, 0.5);
   libra::DualQuaternion dq_out = dq.QuaternionConjugate();
 
   EXPECT_DOUBLE_EQ(-0.5, dq_out.GetRealPart()[0]);
   EXPECT_DOUBLE_EQ(-0.5, dq_out.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(-0.5, dq_out.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetRealPart()[2]);
   EXPECT_DOUBLE_EQ(0.5, dq_out.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(-0.5, dq_out.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[0]);
   EXPECT_DOUBLE_EQ(-0.5, dq_out.GetDualPart()[1]);
   EXPECT_DOUBLE_EQ(-0.5, dq_out.GetDualPart()[2]);
   EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[3]);
 }
 
 TEST(DualQuaternion, DualQuaternionConjugate) {
-  libra::DualQuaternion dq(0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5);
+  libra::DualQuaternion dq(0.5, 0.5, -0.5, 0.5, -0.5, 0.5, 0.5, 0.5);
   libra::DualQuaternion dq_out = dq.DualQuaternionConjugate();
 
   EXPECT_DOUBLE_EQ(-0.5, dq_out.GetRealPart()[0]);
   EXPECT_DOUBLE_EQ(-0.5, dq_out.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(-0.5, dq_out.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetRealPart()[2]);
   EXPECT_DOUBLE_EQ(0.5, dq_out.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(-0.5, dq_out.GetDualPart()[0]);
   EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[1]);
   EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[2]);
   EXPECT_DOUBLE_EQ(-0.5, dq_out.GetDualPart()[3]);
 }
 
+TEST(DualQuaternion, Inverse) {
+  libra::DualQuaternion dq(0.5, 0.5, -0.5, 0.5, -0.5, 0.5, 0.5, 0.5);
+  libra::DualQuaternion dq_out = dq.Inverse();
+
+  EXPECT_DOUBLE_EQ(-0.5, dq_out.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(-0.5, dq_out.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(-0.5, dq_out.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(-0.5, dq_out.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[3]);
+}
 /*
 TEST(DualQuaternion, TransformVectorXrot) {
   libra::Quaternion q_rot(1.0, 0.0, 0.0, 1.0);  // 90deg rotation around X axis
@@ -191,50 +204,78 @@ TEST(DualQuaternion, TransformVectorAllAxes) {
 }
 */
 
+TEST(DualQuaternion, CalcScrewParametersNoRotation) {
+  // No rotation error
+  libra::DualQuaternion dq(0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
+  libra::ScrewParameters screw = dq.CalcScrewParameters();
+
+  EXPECT_DOUBLE_EQ(0.0, screw.angle_rad_);
+  EXPECT_DOUBLE_EQ(0.0, screw.pitch_);
+  EXPECT_DOUBLE_EQ(0.0, screw.axis_[0]);
+  EXPECT_DOUBLE_EQ(0.0, screw.axis_[1]);
+  EXPECT_DOUBLE_EQ(0.0, screw.axis_[2]);
+  EXPECT_DOUBLE_EQ(0.0, screw.moment_[0]);
+  EXPECT_DOUBLE_EQ(0.0, screw.moment_[1]);
+  EXPECT_DOUBLE_EQ(0.0, screw.moment_[2]);
+}
+
+TEST(DualQuaternion, CalcScrewParameters) {
+  libra::DualQuaternion dq(0.707, 0.0, 0.0, 0.707, 0.5, 0.5, 0.5, 0.5);
+  libra::ScrewParameters screw = dq.CalcScrewParameters();
+
+  EXPECT_NEAR(1.5707, screw.angle_rad_, 1e-3);
+  EXPECT_NEAR(-1.4144, screw.pitch_, 1e-3);
+  EXPECT_NEAR(1.0, screw.axis_[0], 1e-3);
+  EXPECT_NEAR(0.0, screw.axis_[1], 1e-3);
+  EXPECT_NEAR(0.0, screw.axis_[2], 1e-3);
+  EXPECT_NEAR(1.4144, screw.moment_[0], 1e-3);
+  EXPECT_NEAR(0.7072, screw.moment_[1], 1e-3);
+  EXPECT_NEAR(0.7072, screw.moment_[2], 1e-3);
+}
+
 TEST(DualQuaternion, Addition) {
-  libra::DualQuaternion dq_lhs(0, 0, 0, 1, 0, 0, 0, 1);
-  libra::DualQuaternion dq_rhs(0, 0, 0, 1, 0, 0, 0, 1);
+  libra::DualQuaternion dq_lhs(0.1, 0.2, 0.3, 1, 0.4, 0.5, 0.6, 1);
+  libra::DualQuaternion dq_rhs(-0.7, 0.8, 0.9, 1, 0.1, -0.2, 0.3, 1);
   libra::DualQuaternion dq_out = dq_lhs + dq_rhs;
 
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(-0.6, dq_out.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(1.0, dq_out.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(1.2, dq_out.GetRealPart()[2]);
   EXPECT_DOUBLE_EQ(2.0, dq_out.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(0.3, dq_out.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(0.9, dq_out.GetDualPart()[2]);
   EXPECT_DOUBLE_EQ(2.0, dq_out.GetDualPart()[3]);
 }
 
-
 TEST(DualQuaternion, Subtraction) {
-  libra::DualQuaternion dq_lhs(0, 0, 0, 3, 0, 0, 0, 3);
-  libra::DualQuaternion dq_rhs(0, 0, 0, 1, 0, 0, 0, 1);
+  libra::DualQuaternion dq_lhs(0.1, 0.2, 0.3, 0.5, 0.4, 0.5, 0.6, 1);
+  libra::DualQuaternion dq_rhs(-0.7, 0.8, 0.9, 1, 0.1, -0.2, 0.3, 0.5);
   libra::DualQuaternion dq_out = dq_lhs - dq_rhs;
 
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[2]);
-  EXPECT_DOUBLE_EQ(2.0, dq_out.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[2]);
-  EXPECT_DOUBLE_EQ(2.0, dq_out.GetDualPart()[3]);
+  EXPECT_DOUBLE_EQ(0.8, dq_out.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(-0.6, dq_out.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(-0.6, dq_out.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(-0.5, dq_out.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.3, dq_out.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(0.7, dq_out.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(0.3, dq_out.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[3]);
 }
 
 TEST(DualQuaternion, ScalarProduction) {
-  libra::DualQuaternion dq(0, 0, 0, 1, 0, 0, 0, 1);
+  libra::DualQuaternion dq(0.5, 0.5, 0.5, 0.5, -0.1, -0.2, -0.3, -2);
   double scalar = 2.0;
   libra::DualQuaternion dq_out = scalar * dq;
 
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[2]);
-  EXPECT_DOUBLE_EQ(2.0, dq_out.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[2]);
-  EXPECT_DOUBLE_EQ(2.0, dq_out.GetDualPart()[3]);
+  EXPECT_DOUBLE_EQ(1.0, dq_out.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(1.0, dq_out.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(1.0, dq_out.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(1.0, dq_out.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(-0.2, dq_out.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(-0.4, dq_out.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(-0.6, dq_out.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(-4.0, dq_out.GetDualPart()[3]);
 }
 
 TEST(DualQuaternion, DualQuaternionProduction) {

--- a/s2e-ff/test/TestDualQuaternion.cpp
+++ b/s2e-ff/test/TestDualQuaternion.cpp
@@ -43,86 +43,6 @@ TEST(DualQuaternion, ConstructorFromEightValue) {
   EXPECT_DOUBLE_EQ(1.0, dq.GetDualPart()[3]);
 }
 
-TEST(DualQuaternion, ConstructorFromRotationTranslation) {
-  libra::Quaternion q_rot(1.0, 0.0, 0.0, 1.0);  // 90deg rotation around X axis
-  libra::Vector<3> v_translation;
-  v_translation[0] = 0.0;
-  v_translation[1] = 0.0;
-  v_translation[2] = 2.0;
-  libra::DualQuaternion dq(q_rot, v_translation);
-
-  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetRealPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[2]);
-  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[0]);
-  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetDualPart()[1]);
-  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetDualPart()[2]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[3]);
-
-  libra::Vector<3> v_out = dq.GetRotationFirstTranslationVector();
-  EXPECT_DOUBLE_EQ(v_translation[0], v_out[0]);
-  EXPECT_DOUBLE_EQ(v_translation[1], v_out[1]);
-  EXPECT_DOUBLE_EQ(v_translation[2], v_out[2]);
-}
-
-TEST(DualQuaternion, ConstructorFromTranslationRotation) {
-  libra::Vector<3> v_translation;
-  v_translation[0] = 0.0;
-  v_translation[1] = 0.0;
-  v_translation[2] = 2.0;
-  libra::Quaternion q_rot(1.0, 0.0, 0.0, 1.0);  // 90deg rotation around X axis
-
-  libra::DualQuaternion dq(v_translation, q_rot);
-
-  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetRealPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[2]);
-  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[0]);
-  EXPECT_DOUBLE_EQ(-1.0 / sqrt(2.0), dq.GetDualPart()[1]);
-  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetDualPart()[2]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[3]);
-
-  libra::Vector<3> v_out = dq.GetTranslationFirstTranslationVector();
-  EXPECT_DOUBLE_EQ(v_translation[0], v_out[0]);
-  EXPECT_DOUBLE_EQ(v_translation[1], v_out[1]);
-  EXPECT_DOUBLE_EQ(v_translation[2], v_out[2]);
-}
-
-TEST(DualQuaternion, Normalize) {
-  libra::DualQuaternion dq(0, 0, 0, 2, 0, 0, 1, 0);
-  libra::DualQuaternion dq_out = dq.CalcNormalizedRotationQauternion();
-
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[2]);
-  EXPECT_DOUBLE_EQ(2.0, dq.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[1]);
-  EXPECT_DOUBLE_EQ(1.0, dq.GetDualPart()[2]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[3]);
-
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[2]);
-  EXPECT_DOUBLE_EQ(1.0, dq_out.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[1]);
-  EXPECT_DOUBLE_EQ(2.0, dq_out.GetDualPart()[2]);
-  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[3]);
-
-  dq.NormalizeRotationQauternion();
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[1]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[2]);
-  EXPECT_DOUBLE_EQ(1.0, dq.GetRealPart()[3]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[0]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[1]);
-  EXPECT_DOUBLE_EQ(2.0, dq.GetDualPart()[2]);
-  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[3]);
-}
-
 TEST(DualQuaternion, DualNumberConjugate) {
   libra::DualQuaternion dq(0, 0, 0, 1, 0, 0, 0, 1);
   libra::DualQuaternion dq_out = dq.DualNumberConjugate();
@@ -164,7 +84,7 @@ TEST(DualQuaternion, DualQuaternionConjugate) {
   EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[2]);
   EXPECT_DOUBLE_EQ(-0.5, dq_out.GetDualPart()[3]);
 }
-
+/*
 TEST(DualQuaternion, TransformVectorXrot) {
   libra::Quaternion q_rot(1.0, 0.0, 0.0, 1.0);  // 90deg rotation around X axis
   libra::Vector<3> v_translation;
@@ -268,93 +188,6 @@ TEST(DualQuaternion, TransformVectorAllAxes) {
   EXPECT_NEAR(v_in[1], v_out_inverse[1], 1e-9);
   EXPECT_NEAR(v_in[2], v_out_inverse[2], 1e-9);
 }
-
-TEST(DualQuaternion, Integral) {
-  libra::DualQuaternion dq(0, 0, 0, 1, 0, 0, 0, 0);
-  libra::Vector<3> omega;
-  omega[0] = 0.01745329;
-  omega[1] = 0.0;
-  omega[2] = 0.0;
-  libra::Vector<3> velocity;
-  velocity[0] = 1.0;
-  velocity[1] = 0.0;
-  velocity[2] = 0.0;
-  double dt = 1.0;
-
-  for (int i = 0; i < 90; i++) {
-    dq = dq.Integrate(omega, velocity, dt);
-  }
-
-  EXPECT_NEAR(0.7071, dq.GetRealPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq.GetRealPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq.GetRealPart()[2], 1e-3);
-  EXPECT_NEAR(0.7071, dq.GetRealPart()[3], 1e-3);
-  EXPECT_NEAR(31.823, dq.GetDualPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq.GetDualPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq.GetDualPart()[2], 1e-3);
-  EXPECT_NEAR(-31.822, dq.GetDualPart()[3], 1e-3);
-
-  libra::Vector<3> v_in;
-  v_in[0] = 1.0;
-  v_in[1] = 1.0;
-  v_in[2] = 0.0;
-
-  libra::Vector<3> v_out = dq.TransformVector(v_in);
-
-  EXPECT_NEAR(91.0, v_out[0], 1e-2);
-  EXPECT_NEAR(0.0, v_out[1], 1e-2);
-  EXPECT_NEAR(1.0, v_out[2], 1e-2);
-}
-
-TEST(DualQuaternion, SclerpTranslationOnly) {
-  libra::DualQuaternion dq1(0, 0, 0, 1, 0, 0, 0, 0);
-  libra::DualQuaternion dq2(0, 0, 0, 1, 1, 0, 0, 0);
-
-  libra::DualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
-
-  EXPECT_NEAR(0.0, dq_out.GetRealPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
-  EXPECT_NEAR(1.0, dq_out.GetRealPart()[3], 1e-3);
-  EXPECT_NEAR(0.5, dq_out.GetDualPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[2], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[3], 1e-3);
-}
-
-TEST(DualQuaternion, Sclerp) {
-  libra::DualQuaternion dq1(0, 0, 0, 1, 0, 0, 0, 0);
-  // X 90deg rotation and X axis translation
-  libra::Quaternion q2_rot(1.0, 0.0, 0.0, 1.0);
-  libra::Vector<3> v2_translation;
-  v2_translation[0] = 1.0;
-  v2_translation[1] = 0.0;
-  v2_translation[2] = 0.0;
-  libra::DualQuaternion dq2(q2_rot, v2_translation);
-
-  // X 45deg rotation and X axis harf translation
-  libra::DualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
-
-  EXPECT_NEAR(0.3826, dq_out.GetRealPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
-  EXPECT_NEAR(0.9239, dq_out.GetRealPart()[3], 1e-3);
-  EXPECT_NEAR(0.23097, dq_out.GetDualPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[2], 1e-3);
-  EXPECT_NEAR(-0.0957, dq_out.GetDualPart()[3], 1e-3);
-
-  libra::Vector<3> v_in;
-  v_in[0] = 1.0;
-  v_in[1] = 1.0;
-  v_in[2] = 0.0;
-
-  libra::Vector<3> v_out = dq_out.TransformVector(v_in);
-  EXPECT_NEAR(1.5, v_out[0], 1e-3);
-  EXPECT_NEAR(0.7071, v_out[1], 1e-3);
-  EXPECT_NEAR(0.7071, v_out[2], 1e-3);
-}
-
 TEST(DualQuaternion, Addition) {
   libra::DualQuaternion dq_lhs(0, 0, 0, 1, 0, 0, 0, 1);
   libra::DualQuaternion dq_rhs(0, 0, 0, 1, 0, 0, 0, 1);
@@ -369,6 +202,7 @@ TEST(DualQuaternion, Addition) {
   EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[2]);
   EXPECT_DOUBLE_EQ(2.0, dq_out.GetDualPart()[3]);
 }
+*/
 
 TEST(DualQuaternion, Subtraction) {
   libra::DualQuaternion dq_lhs(0, 0, 0, 3, 0, 0, 0, 3);

--- a/s2e-ff/test/TestDualQuaternion.cpp
+++ b/s2e-ff/test/TestDualQuaternion.cpp
@@ -84,6 +84,7 @@ TEST(DualQuaternion, DualQuaternionConjugate) {
   EXPECT_DOUBLE_EQ(0.5, dq_out.GetDualPart()[2]);
   EXPECT_DOUBLE_EQ(-0.5, dq_out.GetDualPart()[3]);
 }
+
 /*
 TEST(DualQuaternion, TransformVectorXrot) {
   libra::Quaternion q_rot(1.0, 0.0, 0.0, 1.0);  // 90deg rotation around X axis
@@ -188,6 +189,8 @@ TEST(DualQuaternion, TransformVectorAllAxes) {
   EXPECT_NEAR(v_in[1], v_out_inverse[1], 1e-9);
   EXPECT_NEAR(v_in[2], v_out_inverse[2], 1e-9);
 }
+*/
+
 TEST(DualQuaternion, Addition) {
   libra::DualQuaternion dq_lhs(0, 0, 0, 1, 0, 0, 0, 1);
   libra::DualQuaternion dq_rhs(0, 0, 0, 1, 0, 0, 0, 1);
@@ -202,7 +205,7 @@ TEST(DualQuaternion, Addition) {
   EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[2]);
   EXPECT_DOUBLE_EQ(2.0, dq_out.GetDualPart()[3]);
 }
-*/
+
 
 TEST(DualQuaternion, Subtraction) {
   libra::DualQuaternion dq_lhs(0, 0, 0, 3, 0, 0, 0, 3);

--- a/s2e-ff/test/TestDualQuaternion.cpp
+++ b/s2e-ff/test/TestDualQuaternion.cpp
@@ -60,7 +60,31 @@ TEST(DualQuaternion, ConstructorFromRotationTranslation) {
   EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetDualPart()[2]);
   EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[3]);
 
-  libra::Vector<3> v_out = dq.GetTranslationVector();
+  libra::Vector<3> v_out = dq.GetRotationFirstTranslationVector();
+  EXPECT_DOUBLE_EQ(v_translation[0], v_out[0]);
+  EXPECT_DOUBLE_EQ(v_translation[1], v_out[1]);
+  EXPECT_DOUBLE_EQ(v_translation[2], v_out[2]);
+}
+
+TEST(DualQuaternion, ConstructorFromTranslationRotation) {
+  libra::Vector<3> v_translation;
+  v_translation[0] = 0.0;
+  v_translation[1] = 0.0;
+  v_translation[2] = 2.0;
+  libra::Quaternion q_rot(1.0, 0.0, 0.0, 1.0);  // 90deg rotation around X axis
+
+  libra::DualQuaternion dq(v_translation, q_rot);
+
+  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(-1.0 / sqrt(2.0), dq.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[3]);
+
+  libra::Vector<3> v_out = dq.GetTranslationFirstTranslationVector();
   EXPECT_DOUBLE_EQ(v_translation[0], v_out[0]);
   EXPECT_DOUBLE_EQ(v_translation[1], v_out[1]);
   EXPECT_DOUBLE_EQ(v_translation[2], v_out[2]);

--- a/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
@@ -121,22 +121,46 @@ TEST(RotationFirstDualQuaternion, Integral) {
 }
 
 TEST(RotationFirstDualQuaternion, SclerpTranslationOnly) {
-  libra::DualQuaternion dq1(0, 0, 0, 1, 0, 0, 0, 0);
-  libra::DualQuaternion dq2(0, 0, 0, 1, 1, 0, 0, 0);
+  // Initial DualQuaternion
+  libra::Vector<3> q1_axis;
+  q1_axis[0] = 1.0;
+  q1_axis[1] = 0.0;
+  q1_axis[2] = 0.0;
+  libra::Quaternion q1_rot(q1_axis, 0.0);
+  libra::Vector<3> v1_translation;
+  v1_translation[0] = 0.0;
+  v1_translation[1] = 0.0;
+  v1_translation[2] = 0.0;
+  libra::RotationFirstDualQuaternion dq1(q1_rot, v1_translation);
 
-  libra::DualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
+  libra::Vector<3> q2_axis;
+  q2_axis[0] = 1.0;
+  q2_axis[1] = 0.0;
+  q2_axis[2] = 0.0;
+  libra::Quaternion q2_rot(q2_axis, 0.0);
+  libra::Vector<3> v2_translation;
+  v2_translation[0] = 1.0;
+  v2_translation[1] = 1.0;
+  v2_translation[2] = 1.0;
+  libra::RotationFirstDualQuaternion dq2(q2_rot, v2_translation);
+
+  libra::RotationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[0], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
   EXPECT_NEAR(1.0, dq_out.GetRealPart()[3], 1e-3);
-  EXPECT_NEAR(0.5, dq_out.GetDualPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[2], 1e-3);
+  EXPECT_NEAR(0.25, dq_out.GetDualPart()[0], 1e-3);
+  EXPECT_NEAR(0.25, dq_out.GetDualPart()[1], 1e-3);
+  EXPECT_NEAR(0.25, dq_out.GetDualPart()[2], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetDualPart()[3], 1e-3);
+
+  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[0], 1e-2);
+  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[1], 1e-2);
+  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[2], 1e-2);
 }
 
-TEST(RotationFirstDualQuaternion, Sclerp) {
+TEST(RotationFirstDualQuaternion, SclerpXAxisOnly) {
   // Initial DualQuaternion
   libra::Vector<3> q1_axis;
   q1_axis[0] = 1.0;
@@ -149,7 +173,7 @@ TEST(RotationFirstDualQuaternion, Sclerp) {
   v1_translation[2] = 0.0;
   libra::RotationFirstDualQuaternion dq1(q1_rot, v1_translation);
 
-  // X 90deg rotation and X axis translation
+  // X 180deg rotation and X axis translation
   libra::Vector<3> q2_axis;
   q2_axis[0] = 1.0;
   q2_axis[1] = 0.0;
@@ -161,7 +185,7 @@ TEST(RotationFirstDualQuaternion, Sclerp) {
   v2_translation[2] = 0.0;
   libra::RotationFirstDualQuaternion dq2(q2_rot, v2_translation);
 
-  // X 45deg rotation and X axis harf translation
+  // X 90deg rotation and X axis harf translation
   libra::RotationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
   // Check rotation: 45 deg around X
@@ -200,7 +224,7 @@ TEST(RotationFirstDualQuaternion, Sclerp2) {
   v1_translation[2] = 0.0;
   libra::RotationFirstDualQuaternion dq1(q1_rot, v1_translation);
 
-  // X 90deg rotation and X axis translation
+  // X 180deg rotation and X axis translation
   libra::Vector<3> q2_axis;
   q2_axis[0] = 1.0;
   q2_axis[1] = 0.0;
@@ -212,7 +236,7 @@ TEST(RotationFirstDualQuaternion, Sclerp2) {
   v2_translation[2] = 0.0;
   libra::RotationFirstDualQuaternion dq2(q2_rot, v2_translation);
 
-  // X 45deg rotation and X axis harf translation
+  // X 90deg rotation and X-Y axis translation
   libra::RotationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
   // Check rotation: 45 deg around X

--- a/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
@@ -138,7 +138,11 @@ TEST(RotationFirstDualQuaternion, SclerpTranslationOnly) {
 
 TEST(RotationFirstDualQuaternion, Sclerp) {
   // Initial DualQuaternion
-  libra::Quaternion q1_rot(0.0, 0.0, 0.0, 1.0);
+  libra::Vector<3> q1_axis;
+  q1_axis[0] = 1.0;
+  q1_axis[1] = 0.0;
+  q1_axis[2] = 0.0;
+  libra::Quaternion q1_rot(q1_axis, 0.0);
   libra::Vector<3> v1_translation;
   v1_translation[0] = 0.0;
   v1_translation[1] = 1.0;
@@ -146,10 +150,14 @@ TEST(RotationFirstDualQuaternion, Sclerp) {
   libra::RotationFirstDualQuaternion dq1(q1_rot, v1_translation);
 
   // X 90deg rotation and X axis translation
-  libra::Quaternion q2_rot(1.0, 0.0, 0.0, 1.0);
+  libra::Vector<3> q2_axis;
+  q2_axis[0] = 1.0;
+  q2_axis[1] = 0.0;
+  q2_axis[2] = 0.0;
+  libra::Quaternion q2_rot(q1_axis, 3.14159);
   libra::Vector<3> v2_translation;
   v2_translation[0] = 1.0;
-  v2_translation[1] = 0.0;
+  v2_translation[1] = 1.0;
   v2_translation[2] = 0.0;
   libra::RotationFirstDualQuaternion dq2(q2_rot, v2_translation);
 
@@ -157,24 +165,24 @@ TEST(RotationFirstDualQuaternion, Sclerp) {
   libra::RotationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
   // Check rotation: 45 deg around X
-  EXPECT_NEAR(0.3826, dq_out.GetRealPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
-  EXPECT_NEAR(0.9239, dq_out.GetRealPart()[3], 1e-3);
+  EXPECT_NEAR(0.7071, dq_out.GetRealPart()[0], 1e-2);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-2);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-2);
+  EXPECT_NEAR(0.7071, dq_out.GetRealPart()[3], 1e-2);
 
   // Check translation: 0.5 move on X axis
-  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[0], 1e-3);
-  EXPECT_NEAR(1.0, dq_out.GetTranslationVector()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetTranslationVector()[2], 1e-3);
+  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[0], 1e-2);
+  EXPECT_NEAR(1.0, dq_out.GetTranslationVector()[1], 1e-2);
+  EXPECT_NEAR(0.0, dq_out.GetTranslationVector()[2], 1e-2);
 
   // Check vector transform
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
-  v_in[1] = 1.0;
+  v_in[1] = -1.0;
   v_in[2] = 0.0;
 
   libra::Vector<3> v_out = dq_out.TransformVector(v_in);
-  EXPECT_NEAR(1.5, v_out[0], 1e-3);
-  EXPECT_NEAR(1.7071, v_out[1], 1e-3);
-  EXPECT_NEAR(0.7071, v_out[2], 1e-3);
+  EXPECT_NEAR(1.5, v_out[0], 1e-2);
+  EXPECT_NEAR(1.0, v_out[1], 1e-2);
+  EXPECT_NEAR(-1.0, v_out[2], 1e-2);
 }

--- a/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
@@ -62,16 +62,16 @@ TEST(RotationFirstDualQuaternion, Normalize) {
 TEST(RotationFirstDualQuaternion, Integral) {
   libra::RotationFirstDualQuaternion dq;
   libra::Vector<3> omega;
-  omega[0] = 0.01745329;
+  omega[0] = 0.01745329;  // 1 deg/s
   omega[1] = 0.0;
   omega[2] = 0.0;
   libra::Vector<3> velocity;
   velocity[0] = 1.0;
   velocity[1] = 0.0;
   velocity[2] = 0.0;
-  double dt = 1.0;
+  double dt = 0.1;
 
-  for (int i = 0; i < 90; i++) {
+  for (int i = 0; i < 900; i++) {
     dq = dq.Integrate(omega, velocity, dt);
   }
 
@@ -79,10 +79,6 @@ TEST(RotationFirstDualQuaternion, Integral) {
   EXPECT_NEAR(0.0, dq.GetRealPart()[1], 1e-3);
   EXPECT_NEAR(0.0, dq.GetRealPart()[2], 1e-3);
   EXPECT_NEAR(0.7071, dq.GetRealPart()[3], 1e-3);
-  EXPECT_NEAR(31.823, dq.GetDualPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq.GetDualPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq.GetDualPart()[2], 1e-3);
-  EXPECT_NEAR(-31.822, dq.GetDualPart()[3], 1e-3);
 
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
@@ -91,9 +87,9 @@ TEST(RotationFirstDualQuaternion, Integral) {
 
   libra::Vector<3> v_out = dq.TransformVector(v_in);
 
-  EXPECT_NEAR(91.0, v_out[0], 1e-2);
-  EXPECT_NEAR(0.0, v_out[1], 1e-2);
-  EXPECT_NEAR(1.0, v_out[2], 1e-2);
+  EXPECT_NEAR(91.0, v_out[0], 1e-1);
+  EXPECT_NEAR(0.0, v_out[1], 1e-1);
+  EXPECT_NEAR(1.0, v_out[2], 1e-1);
 }
 
 TEST(RotationFirstDualQuaternion, SclerpTranslationOnly) {

--- a/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
@@ -1,0 +1,146 @@
+#include <gtest/gtest.h>
+
+#include "../src/Library/math/RotationFirstDualQuaternion.hpp"
+
+TEST(RotationFirstDualQuaternion, ConstructorFromRotationTranslation) {
+  libra::Quaternion q_rot(1.0, 0.0, 0.0, 1.0);  // 90deg rotation around X axis
+  libra::Vector<3> v_translation;
+  v_translation[0] = 0.0;
+  v_translation[1] = 0.0;
+  v_translation[2] = 2.0;
+  libra::RotationFirstDualQuaternion dq(q_rot, v_translation);
+
+  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[3]);
+
+  libra::Vector<3> v_out = dq.GetTranslationVector();
+  EXPECT_DOUBLE_EQ(v_translation[0], v_out[0]);
+  EXPECT_DOUBLE_EQ(v_translation[1], v_out[1]);
+  EXPECT_DOUBLE_EQ(v_translation[2], v_out[2]);
+}
+
+TEST(RotationFirstDualQuaternion, Normalize) {
+  libra::DualQuaternion dq(0, 0, 0, 2, 0, 0, 1, 0);
+  libra::RotationFirstDualQuaternion dq_in(dq);
+  libra::RotationFirstDualQuaternion dq_out = dq_in.CalcNormalizedRotationQauternion();
+
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(2.0, dq_in.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(1.0, dq_in.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[3]);
+
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(1.0, dq_out.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(2.0, dq_out.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[3]);
+
+  dq_in.NormalizeRotationQauternion();
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(1.0, dq_in.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(2.0, dq_in.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[3]);
+}
+
+TEST(RotationFirstDualQuaternion, Integral) {
+  libra::RotationFirstDualQuaternion dq;
+  libra::Vector<3> omega;
+  omega[0] = 0.01745329;
+  omega[1] = 0.0;
+  omega[2] = 0.0;
+  libra::Vector<3> velocity;
+  velocity[0] = 1.0;
+  velocity[1] = 0.0;
+  velocity[2] = 0.0;
+  double dt = 1.0;
+
+  for (int i = 0; i < 90; i++) {
+    dq = dq.Integrate(omega, velocity, dt);
+  }
+
+  EXPECT_NEAR(0.7071, dq.GetRealPart()[0], 1e-3);
+  EXPECT_NEAR(0.0, dq.GetRealPart()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq.GetRealPart()[2], 1e-3);
+  EXPECT_NEAR(0.7071, dq.GetRealPart()[3], 1e-3);
+  EXPECT_NEAR(31.823, dq.GetDualPart()[0], 1e-3);
+  EXPECT_NEAR(0.0, dq.GetDualPart()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq.GetDualPart()[2], 1e-3);
+  EXPECT_NEAR(-31.822, dq.GetDualPart()[3], 1e-3);
+
+  libra::Vector<3> v_in;
+  v_in[0] = 1.0;
+  v_in[1] = 1.0;
+  v_in[2] = 0.0;
+
+  libra::Vector<3> v_out = dq.TransformVector(v_in);
+
+  EXPECT_NEAR(91.0, v_out[0], 1e-2);
+  EXPECT_NEAR(0.0, v_out[1], 1e-2);
+  EXPECT_NEAR(1.0, v_out[2], 1e-2);
+}
+
+TEST(RotationFirstDualQuaternion, SclerpTranslationOnly) {
+  libra::DualQuaternion dq1(0, 0, 0, 1, 0, 0, 0, 0);
+  libra::DualQuaternion dq2(0, 0, 0, 1, 1, 0, 0, 0);
+
+  libra::DualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
+
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[0], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
+  EXPECT_NEAR(1.0, dq_out.GetRealPart()[3], 1e-3);
+  EXPECT_NEAR(0.5, dq_out.GetDualPart()[0], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetDualPart()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetDualPart()[2], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetDualPart()[3], 1e-3);
+}
+
+TEST(RotationFirstDualQuaternion, Sclerp) {
+  libra::RotationFirstDualQuaternion dq1;
+  // X 90deg rotation and X axis translation
+  libra::Quaternion q2_rot(1.0, 0.0, 0.0, 1.0);
+  libra::Vector<3> v2_translation;
+  v2_translation[0] = 1.0;
+  v2_translation[1] = 0.0;
+  v2_translation[2] = 0.0;
+  libra::RotationFirstDualQuaternion dq2(q2_rot, v2_translation);
+
+  // X 45deg rotation and X axis harf translation
+  libra::RotationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
+
+  EXPECT_NEAR(0.3826, dq_out.GetRealPart()[0], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
+  EXPECT_NEAR(0.9239, dq_out.GetRealPart()[3], 1e-3);
+  EXPECT_NEAR(0.23097, dq_out.GetDualPart()[0], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetDualPart()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetDualPart()[2], 1e-3);
+  EXPECT_NEAR(-0.0957, dq_out.GetDualPart()[3], 1e-3);
+
+  libra::Vector<3> v_in;
+  v_in[0] = 1.0;
+  v_in[1] = 1.0;
+  v_in[2] = 0.0;
+
+  libra::Vector<3> v_out = dq_out.TransformVector(v_in);
+  EXPECT_NEAR(1.5, v_out[0], 1e-3);
+  EXPECT_NEAR(0.7071, v_out[1], 1e-3);
+  EXPECT_NEAR(0.7071, v_out[2], 1e-3);
+}

--- a/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
@@ -89,10 +89,10 @@ TEST(RotationFirstDualQuaternion, Integral) {
   velocity[0] = 1.0;
   velocity[1] = 0.0;
   velocity[2] = 0.0;
-  double dt = 0.1;
+  double dt = 0.01;
 
   // Integrations
-  for (int i = 0; i < 900; i++) {
+  for (int i = 0; i < 9000; i++) {
     dq = dq.Integrate(omega, velocity, dt);
   }
 
@@ -103,21 +103,21 @@ TEST(RotationFirstDualQuaternion, Integral) {
   EXPECT_NEAR(0.7071, dq.GetRealPart()[3], 1e-3);
 
   // Check transition
-  EXPECT_NEAR(90.0, dq.GetTranslationVector()[0], 1e-1);
-  EXPECT_NEAR(1.0, dq.GetTranslationVector()[1], 1e-1);
-  EXPECT_NEAR(0.0, dq.GetTranslationVector()[2], 1e-1);
+  EXPECT_NEAR(90.0, dq.GetTranslationVector()[0], 1e-2);
+  EXPECT_NEAR(1.0, dq.GetTranslationVector()[1], 1e-2);
+  EXPECT_NEAR(0.0, dq.GetTranslationVector()[2], 1e-2);
 
   // Check vector transform
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
-  v_in[1] = 0.0;
+  v_in[1] = 1.0;
   v_in[2] = 1.0;
 
   libra::Vector<3> v_out = dq.TransformVector(v_in);
 
-  EXPECT_NEAR(91.0, v_out[0], 1e-1);
-  EXPECT_NEAR(0.0, v_out[1], 1e-1);
-  EXPECT_NEAR(0.0, v_out[2], 1e-1);
+  EXPECT_NEAR(91.0, v_out[0], 1e-2);
+  EXPECT_NEAR(0.0, v_out[1], 1e-2);
+  EXPECT_NEAR(1.0, v_out[2], 1e-2);
 }
 
 TEST(RotationFirstDualQuaternion, SclerpTranslationOnly) {

--- a/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
@@ -23,6 +23,18 @@ TEST(RotationFirstDualQuaternion, ConstructorFromRotationTranslation) {
   EXPECT_DOUBLE_EQ(v_translation[0], v_out[0]);
   EXPECT_DOUBLE_EQ(v_translation[1], v_out[1]);
   EXPECT_DOUBLE_EQ(v_translation[2], v_out[2]);
+
+  // Check vector transform
+  libra::Vector<3> v_in;
+  v_in[0] = 1.0;
+  v_in[1] = 0.0;
+  v_in[2] = 1.0;
+
+  libra::Vector<3> v_conv = dq.TransformVector(v_in);
+
+  EXPECT_NEAR(1.0, v_conv[0], 1e-1);
+  EXPECT_NEAR(-1.0, v_conv[1], 1e-1);
+  EXPECT_NEAR(2.0, v_conv[2], 1e-1);
 }
 
 TEST(RotationFirstDualQuaternion, Normalize) {
@@ -95,7 +107,7 @@ TEST(RotationFirstDualQuaternion, Integral) {
   EXPECT_NEAR(1.0, dq.GetTranslationVector()[1], 1e-1);
   EXPECT_NEAR(0.0, dq.GetTranslationVector()[2], 1e-1);
 
-  // Check frame conversion
+  // Check vector transform
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
   v_in[1] = 0.0;
@@ -125,7 +137,14 @@ TEST(RotationFirstDualQuaternion, SclerpTranslationOnly) {
 }
 
 TEST(RotationFirstDualQuaternion, Sclerp) {
-  libra::RotationFirstDualQuaternion dq1;
+  // Initial DualQuaternion
+  libra::Quaternion q1_rot(0.0, 0.0, 0.0, 1.0);
+  libra::Vector<3> v1_translation;
+  v1_translation[0] = 0.0;
+  v1_translation[1] = 1.0;
+  v1_translation[2] = 0.0;
+  libra::RotationFirstDualQuaternion dq1(q1_rot, v1_translation);
+
   // X 90deg rotation and X axis translation
   libra::Quaternion q2_rot(1.0, 0.0, 0.0, 1.0);
   libra::Vector<3> v2_translation;
@@ -137,15 +156,18 @@ TEST(RotationFirstDualQuaternion, Sclerp) {
   // X 45deg rotation and X axis harf translation
   libra::RotationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
+  // Check rotation: 45 deg around X
   EXPECT_NEAR(0.3826, dq_out.GetRealPart()[0], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
   EXPECT_NEAR(0.9239, dq_out.GetRealPart()[3], 1e-3);
-  EXPECT_NEAR(0.23097, dq_out.GetDualPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[2], 1e-3);
-  EXPECT_NEAR(-0.0957, dq_out.GetDualPart()[3], 1e-3);
 
+  // Check translation: 0.5 move on X axis
+  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[0], 1e-3);
+  EXPECT_NEAR(1.0, dq_out.GetTranslationVector()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetTranslationVector()[2], 1e-3);
+
+  // Check vector transform
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
   v_in[1] = 1.0;
@@ -153,6 +175,6 @@ TEST(RotationFirstDualQuaternion, Sclerp) {
 
   libra::Vector<3> v_out = dq_out.TransformVector(v_in);
   EXPECT_NEAR(1.5, v_out[0], 1e-3);
-  EXPECT_NEAR(0.7071, v_out[1], 1e-3);
+  EXPECT_NEAR(1.7071, v_out[1], 1e-3);
   EXPECT_NEAR(0.7071, v_out[2], 1e-3);
 }

--- a/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
@@ -160,7 +160,7 @@ TEST(RotationFirstDualQuaternion, SclerpTranslationOnly) {
   EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[2], 1e-2);
 }
 
-TEST(RotationFirstDualQuaternion, SclerpXAxisOnly) {
+TEST(RotationFirstDualQuaternion, SclerpXAxisRotXAxisMove) {
   // Initial DualQuaternion
   libra::Vector<3> q1_axis;
   q1_axis[0] = 1.0;
@@ -185,16 +185,13 @@ TEST(RotationFirstDualQuaternion, SclerpXAxisOnly) {
   v2_translation[2] = 0.0;
   libra::RotationFirstDualQuaternion dq2(q2_rot, v2_translation);
 
-  // X 90deg rotation and X axis harf translation
   libra::RotationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
-  // Check rotation: 45 deg around X
   EXPECT_NEAR(0.7071, dq_out.GetRealPart()[0], 1e-2);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-2);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-2);
   EXPECT_NEAR(0.7071, dq_out.GetRealPart()[3], 1e-2);
 
-  // Check translation: 0.5 move on X axis
   EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[0], 1e-2);
   EXPECT_NEAR(1.0, dq_out.GetTranslationVector()[1], 1e-2);
   EXPECT_NEAR(0.0, dq_out.GetTranslationVector()[2], 1e-2);
@@ -211,7 +208,7 @@ TEST(RotationFirstDualQuaternion, SclerpXAxisOnly) {
   EXPECT_NEAR(-1.0, v_out[2], 1e-2);
 }
 
-TEST(RotationFirstDualQuaternion, Sclerp2) {
+TEST(RotationFirstDualQuaternion, SclerpXAxisRotXYAxisMove) {
   // Initial DualQuaternion
   libra::Vector<3> q1_axis;
   q1_axis[0] = 1.0;
@@ -224,7 +221,7 @@ TEST(RotationFirstDualQuaternion, Sclerp2) {
   v1_translation[2] = 0.0;
   libra::RotationFirstDualQuaternion dq1(q1_rot, v1_translation);
 
-  // X 180deg rotation and X axis translation
+  // X 180deg rotation and X axis XY axis translation
   libra::Vector<3> q2_axis;
   q2_axis[0] = 1.0;
   q2_axis[1] = 0.0;
@@ -236,10 +233,9 @@ TEST(RotationFirstDualQuaternion, Sclerp2) {
   v2_translation[2] = 0.0;
   libra::RotationFirstDualQuaternion dq2(q2_rot, v2_translation);
 
-  // X 90deg rotation and X-Y axis translation
   libra::RotationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
-  // Check rotation: 45 deg around X
+  // Check rotation: 90 deg around X
   EXPECT_NEAR(0.7071, dq_out.GetRealPart()[0], 1e-2);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-2);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-2);

--- a/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
@@ -154,7 +154,7 @@ TEST(RotationFirstDualQuaternion, Sclerp) {
   q2_axis[0] = 1.0;
   q2_axis[1] = 0.0;
   q2_axis[2] = 0.0;
-  libra::Quaternion q2_rot(q1_axis, 3.14159);
+  libra::Quaternion q2_rot(q2_axis, 3.14159);
   libra::Vector<3> v2_translation;
   v2_translation[0] = 1.0;
   v2_translation[1] = 1.0;
@@ -185,4 +185,55 @@ TEST(RotationFirstDualQuaternion, Sclerp) {
   EXPECT_NEAR(1.5, v_out[0], 1e-2);
   EXPECT_NEAR(1.0, v_out[1], 1e-2);
   EXPECT_NEAR(-1.0, v_out[2], 1e-2);
+}
+
+TEST(RotationFirstDualQuaternion, Sclerp2) {
+  // Initial DualQuaternion
+  libra::Vector<3> q1_axis;
+  q1_axis[0] = 1.0;
+  q1_axis[1] = 0.0;
+  q1_axis[2] = 0.0;
+  libra::Quaternion q1_rot(q1_axis, 0.0);
+  libra::Vector<3> v1_translation;
+  v1_translation[0] = 0.0;
+  v1_translation[1] = 1.0;
+  v1_translation[2] = 0.0;
+  libra::RotationFirstDualQuaternion dq1(q1_rot, v1_translation);
+
+  // X 90deg rotation and X axis translation
+  libra::Vector<3> q2_axis;
+  q2_axis[0] = 1.0;
+  q2_axis[1] = 0.0;
+  q2_axis[2] = 0.0;
+  libra::Quaternion q2_rot(q2_axis, 3.14159);
+  libra::Vector<3> v2_translation;
+  v2_translation[0] = 2.0;
+  v2_translation[1] = 2.0;
+  v2_translation[2] = 0.0;
+  libra::RotationFirstDualQuaternion dq2(q2_rot, v2_translation);
+
+  // X 45deg rotation and X axis harf translation
+  libra::RotationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
+
+  // Check rotation: 45 deg around X
+  EXPECT_NEAR(0.7071, dq_out.GetRealPart()[0], 1e-2);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-2);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-2);
+  EXPECT_NEAR(0.7071, dq_out.GetRealPart()[3], 1e-2);
+
+  // Check translation: 0.5 move on X axis
+  EXPECT_NEAR(1.0, dq_out.GetTranslationVector()[0], 1e-2);
+  EXPECT_NEAR(1.5, dq_out.GetTranslationVector()[1], 1e-2);
+  EXPECT_NEAR(-0.5, dq_out.GetTranslationVector()[2], 1e-2);
+
+  // Check vector transform
+  libra::Vector<3> v_in;
+  v_in[0] = 1.0;
+  v_in[1] = -1.0;
+  v_in[2] = 0.0;
+
+  libra::Vector<3> v_out = dq_out.TransformVector(v_in);
+  EXPECT_NEAR(2.0, v_out[0], 1e-2);
+  EXPECT_NEAR(1.5, v_out[1], 1e-2);
+  EXPECT_NEAR(-1.5, v_out[2], 1e-2);
 }

--- a/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestRotationFirstDualQuaternion.cpp
@@ -60,7 +60,15 @@ TEST(RotationFirstDualQuaternion, Normalize) {
 }
 
 TEST(RotationFirstDualQuaternion, Integral) {
-  libra::RotationFirstDualQuaternion dq;
+  // Initial DualQuaternion
+  libra::Quaternion q_rot(0.0, 0.0, 0.0, 1.0);
+  libra::Vector<3> v_translation;
+  v_translation[0] = 0.0;
+  v_translation[1] = 1.0;
+  v_translation[2] = 0.0;
+  libra::RotationFirstDualQuaternion dq(q_rot, v_translation);
+
+  // Kinematics condition
   libra::Vector<3> omega;
   omega[0] = 0.01745329;  // 1 deg/s
   omega[1] = 0.0;
@@ -71,25 +79,33 @@ TEST(RotationFirstDualQuaternion, Integral) {
   velocity[2] = 0.0;
   double dt = 0.1;
 
+  // Integrations
   for (int i = 0; i < 900; i++) {
     dq = dq.Integrate(omega, velocity, dt);
   }
 
+  // Check rotation
   EXPECT_NEAR(0.7071, dq.GetRealPart()[0], 1e-3);
   EXPECT_NEAR(0.0, dq.GetRealPart()[1], 1e-3);
   EXPECT_NEAR(0.0, dq.GetRealPart()[2], 1e-3);
   EXPECT_NEAR(0.7071, dq.GetRealPart()[3], 1e-3);
 
+  // Check transition
+  EXPECT_NEAR(90.0, dq.GetTranslationVector()[0], 1e-1);
+  EXPECT_NEAR(1.0, dq.GetTranslationVector()[1], 1e-1);
+  EXPECT_NEAR(0.0, dq.GetTranslationVector()[2], 1e-1);
+
+  // Check frame conversion
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
-  v_in[1] = 1.0;
-  v_in[2] = 0.0;
+  v_in[1] = 0.0;
+  v_in[2] = 1.0;
 
   libra::Vector<3> v_out = dq.TransformVector(v_in);
 
   EXPECT_NEAR(91.0, v_out[0], 1e-1);
   EXPECT_NEAR(0.0, v_out[1], 1e-1);
-  EXPECT_NEAR(1.0, v_out[2], 1e-1);
+  EXPECT_NEAR(0.0, v_out[2], 1e-1);
 }
 
 TEST(RotationFirstDualQuaternion, SclerpTranslationOnly) {

--- a/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
@@ -138,34 +138,42 @@ TEST(TranslationFirstDualQuaternion, SclerpTranslationOnly) {
 
 TEST(TranslationFirstDualQuaternion, Sclerp) {
   // Initial DualQuaternion
-  libra::Quaternion q1_rot(0.0, 0.0, 0.0, 1.0);
+  libra::Vector<3> q1_axis;
+  q1_axis[0] = 1.0;
+  q1_axis[1] = 0.0;
+  q1_axis[2] = 0.0;
+  libra::Quaternion q1_rot(q1_axis, 0.0);
   libra::Vector<3> v1_translation;
   v1_translation[0] = 0.0;
   v1_translation[1] = 1.0;
   v1_translation[2] = 0.0;
   libra::TranslationFirstDualQuaternion dq1(v1_translation, q1_rot);
 
-  // X 90deg rotation and X axis translation
-  libra::Quaternion q2_rot(1.0, 0.0, 0.0, 1.0);
+  // X 180deg rotation and X axis translation
+  libra::Vector<3> q2_axis;
+  q2_axis[0] = 1.0;
+  q2_axis[1] = 0.0;
+  q2_axis[2] = 0.0;
+  libra::Quaternion q2_rot(q2_axis, 3.14159);
   libra::Vector<3> v2_translation;
   v2_translation[0] = 1.0;
-  v2_translation[1] = 0.0;
+  v2_translation[1] = 1.0;
   v2_translation[2] = 0.0;
   libra::TranslationFirstDualQuaternion dq2(v2_translation, q2_rot);
 
-  // X 45deg rotation and X axis harf translation
+  // X 90deg rotation and X axis harf translation
   libra::TranslationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
-  // Check rotation
-  EXPECT_NEAR(0.3826, dq_out.GetRealPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
-  EXPECT_NEAR(0.9239, dq_out.GetRealPart()[3], 1e-3);
+  // Check rotation: 45 deg around X
+  EXPECT_NEAR(0.7071, dq_out.GetRealPart()[0], 1e-2);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-2);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-2);
+  EXPECT_NEAR(0.7071, dq_out.GetRealPart()[3], 1e-2);
 
-  // Check rotation
-  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[0], 1e-3);
-  EXPECT_NEAR(0.7071, dq_out.GetTranslationVector()[1], 1e-3);
-  EXPECT_NEAR(-0.7071, dq_out.GetTranslationVector()[2], 1e-3);
+  // Check translation: 0.5 move on X axis
+  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[0], 1e-2);
+  EXPECT_NEAR(1.0, dq_out.GetTranslationVector()[1], 1e-2);
+  EXPECT_NEAR(0.0, dq_out.GetTranslationVector()[2], 1e-2);
 
   // Check vector transform
   libra::Vector<3> v_in;
@@ -174,7 +182,7 @@ TEST(TranslationFirstDualQuaternion, Sclerp) {
   v_in[2] = 0.0;
 
   libra::Vector<3> v_out = dq_out.TransformVector(v_in);
-  EXPECT_NEAR(1.5, v_out[0], 1e-3);
-  EXPECT_NEAR(1.7071, v_out[1], 1e-3);
-  EXPECT_NEAR(0.7071, v_out[2], 1e-3);
+  EXPECT_NEAR(1.5, v_out[0], 1e-2);
+  EXPECT_NEAR(0.0, v_out[1], 1e-2);
+  EXPECT_NEAR(2.0, v_out[2], 1e-2);
 }

--- a/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
@@ -124,7 +124,7 @@ TEST(TranslationFirstDualQuaternion, SclerpTranslationOnly) {
   libra::DualQuaternion dq1(0, 0, 0, 1, 0, 0, 0, 0);
   libra::DualQuaternion dq2(0, 0, 0, 1, 1, 0, 0, 0);
 
-  libra::DualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
+  libra::DualQuaternion dq_out;// = libra::Sclerp(dq1, dq2, 0.5);
 
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[0], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
@@ -154,7 +154,7 @@ TEST(TranslationFirstDualQuaternion, Sclerp) {
   libra::TranslationFirstDualQuaternion dq2(v2_translation, q2_rot);
 
   // X 45deg rotation and X axis harf translation
-  libra::TranslationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
+  libra::TranslationFirstDualQuaternion dq_out;// = libra::Sclerp(dq1, dq2, 0.5);
 
   // Check rotation
   EXPECT_NEAR(0.3826, dq_out.GetRealPart()[0], 1e-3);
@@ -164,8 +164,8 @@ TEST(TranslationFirstDualQuaternion, Sclerp) {
 
   // Check rotation
   EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[0], 1e-3);
-  EXPECT_NEAR(1.0, dq_out.GetTranslationVector()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetTranslationVector()[2], 1e-3);
+  EXPECT_NEAR(0.7071, dq_out.GetTranslationVector()[1], 1e-3);
+  EXPECT_NEAR(-0.7071, dq_out.GetTranslationVector()[2], 1e-3);
 
   // Check vector transform
   libra::Vector<3> v_in;
@@ -175,6 +175,6 @@ TEST(TranslationFirstDualQuaternion, Sclerp) {
 
   libra::Vector<3> v_out = dq_out.TransformVector(v_in);
   EXPECT_NEAR(1.5, v_out[0], 1e-3);
-  EXPECT_NEAR(0.7071, v_out[1], 1e-3);
+  EXPECT_NEAR(1.7071, v_out[1], 1e-3);
   EXPECT_NEAR(0.7071, v_out[2], 1e-3);
 }

--- a/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
@@ -121,22 +121,46 @@ TEST(TranslationFirstDualQuaternion, Integral) {
 }
 
 TEST(TranslationFirstDualQuaternion, SclerpTranslationOnly) {
-  libra::DualQuaternion dq1(0, 0, 0, 1, 0, 0, 0, 0);
-  libra::DualQuaternion dq2(0, 0, 0, 1, 1, 0, 0, 0);
+  // Initial DualQuaternion
+  libra::Vector<3> q1_axis;
+  q1_axis[0] = 1.0;
+  q1_axis[1] = 0.0;
+  q1_axis[2] = 0.0;
+  libra::Quaternion q1_rot(q1_axis, 0.0);
+  libra::Vector<3> v1_translation;
+  v1_translation[0] = 0.0;
+  v1_translation[1] = 0.0;
+  v1_translation[2] = 0.0;
+  libra::TranslationFirstDualQuaternion dq1(v1_translation, q1_rot);
 
-  libra::DualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
+  libra::Vector<3> q2_axis;
+  q2_axis[0] = 1.0;
+  q2_axis[1] = 0.0;
+  q2_axis[2] = 0.0;
+  libra::Quaternion q2_rot(q2_axis, 0.0);
+  libra::Vector<3> v2_translation;
+  v2_translation[0] = 1.0;
+  v2_translation[1] = 1.0;
+  v2_translation[2] = 1.0;
+  libra::TranslationFirstDualQuaternion dq2(v2_translation, q2_rot);
+
+  libra::TranslationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[0], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
   EXPECT_NEAR(1.0, dq_out.GetRealPart()[3], 1e-3);
-  EXPECT_NEAR(0.5, dq_out.GetDualPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[2], 1e-3);
+  EXPECT_NEAR(0.25, dq_out.GetDualPart()[0], 1e-3);
+  EXPECT_NEAR(0.25, dq_out.GetDualPart()[1], 1e-3);
+  EXPECT_NEAR(0.25, dq_out.GetDualPart()[2], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetDualPart()[3], 1e-3);
+
+  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[0], 1e-2);
+  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[1], 1e-2);
+  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[2], 1e-2);
 }
 
-TEST(TranslationFirstDualQuaternion, Sclerp) {
+TEST(TranslationFirstDualQuaternion, SclerpXAxisRotXAxisMove) {
   // Initial DualQuaternion
   libra::Vector<3> q1_axis;
   q1_axis[0] = 1.0;
@@ -185,4 +209,55 @@ TEST(TranslationFirstDualQuaternion, Sclerp) {
   EXPECT_NEAR(1.5, v_out[0], 1e-2);
   EXPECT_NEAR(0.0, v_out[1], 1e-2);
   EXPECT_NEAR(2.0, v_out[2], 1e-2);
+}
+
+TEST(TranslationFirstDualQuaternion, SclerpXAxisRotXYAxisMove) {
+  // Initial DualQuaternion
+  libra::Vector<3> q1_axis;
+  q1_axis[0] = 1.0;
+  q1_axis[1] = 0.0;
+  q1_axis[2] = 0.0;
+  libra::Quaternion q1_rot(q1_axis, 0.0);
+  libra::Vector<3> v1_translation;
+  v1_translation[0] = 0.0;
+  v1_translation[1] = 1.0;
+  v1_translation[2] = 0.0;
+  libra::TranslationFirstDualQuaternion dq1(v1_translation, q1_rot);
+
+  // X 180deg rotation and X axis translation
+  libra::Vector<3> q2_axis;
+  q2_axis[0] = 1.0;
+  q2_axis[1] = 0.0;
+  q2_axis[2] = 0.0;
+  libra::Quaternion q2_rot(q2_axis, 3.14159);
+  libra::Vector<3> v2_translation;
+  v2_translation[0] = 2.0;
+  v2_translation[1] = 2.0;
+  v2_translation[2] = 0.0;
+  libra::TranslationFirstDualQuaternion dq2(v2_translation, q2_rot);
+
+  // X 90deg rotation and X-Y axis translation
+  libra::TranslationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
+
+  // Check rotation: 45 deg around X
+  EXPECT_NEAR(0.7071, dq_out.GetRealPart()[0], 1e-2);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-2);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-2);
+  EXPECT_NEAR(0.7071, dq_out.GetRealPart()[3], 1e-2);
+
+  // Check translation: 0.5 move on X axis
+  EXPECT_NEAR(1.0, dq_out.GetTranslationVector()[0], 1e-2);
+  EXPECT_NEAR(1.5, dq_out.GetTranslationVector()[1], 1e-2);
+  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[2], 1e-2);
+
+  // Check vector transform
+  libra::Vector<3> v_in;
+  v_in[0] = 1.0;
+  v_in[1] = -1.0;
+  v_in[2] = 0.0;
+
+  libra::Vector<3> v_out = dq_out.TransformVector(v_in);
+  EXPECT_NEAR(2.0, v_out[0], 1e-2);
+  EXPECT_NEAR(-0.5, v_out[1], 1e-2);
+  EXPECT_NEAR(0.5, v_out[2], 1e-2);
 }

--- a/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
@@ -124,7 +124,7 @@ TEST(TranslationFirstDualQuaternion, SclerpTranslationOnly) {
   libra::DualQuaternion dq1(0, 0, 0, 1, 0, 0, 0, 0);
   libra::DualQuaternion dq2(0, 0, 0, 1, 1, 0, 0, 0);
 
-  libra::DualQuaternion dq_out;// = libra::Sclerp(dq1, dq2, 0.5);
+  libra::DualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[0], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
@@ -154,7 +154,7 @@ TEST(TranslationFirstDualQuaternion, Sclerp) {
   libra::TranslationFirstDualQuaternion dq2(v2_translation, q2_rot);
 
   // X 45deg rotation and X axis harf translation
-  libra::TranslationFirstDualQuaternion dq_out;// = libra::Sclerp(dq1, dq2, 0.5);
+  libra::TranslationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
   // Check rotation
   EXPECT_NEAR(0.3826, dq_out.GetRealPart()[0], 1e-3);

--- a/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
@@ -23,6 +23,18 @@ TEST(TranslationFirstDualQuaternion, ConstructorFromRotationTranslation) {
   EXPECT_DOUBLE_EQ(v_translation[0], v_out[0]);
   EXPECT_DOUBLE_EQ(v_translation[1], v_out[1]);
   EXPECT_DOUBLE_EQ(v_translation[2], v_out[2]);
+
+  // Check vector transform
+  libra::Vector<3> v_in;
+  v_in[0] = 1.0;
+  v_in[1] = 0.0;
+  v_in[2] = 1.0;
+
+  libra::Vector<3> v_conv = dq.TransformVector(v_in);
+
+  EXPECT_NEAR(1.0, v_conv[0], 1e-1);
+  EXPECT_NEAR(-3.0, v_conv[1], 1e-1);
+  EXPECT_NEAR(0.0, v_conv[2], 1e-1);
 }
 
 TEST(TranslationFirstDualQuaternion, Normalize) {
@@ -95,7 +107,7 @@ TEST(TranslationFirstDualQuaternion, Integral) {
   EXPECT_NEAR(1.0, dq.GetTranslationVector()[1], 1e-1);
   EXPECT_NEAR(0.0, dq.GetTranslationVector()[2], 1e-1);
 
-  // Check frame conversion
+  // Check vector transform
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
   v_in[1] = 0.0;
@@ -125,7 +137,14 @@ TEST(TranslationFirstDualQuaternion, SclerpTranslationOnly) {
 }
 
 TEST(TranslationFirstDualQuaternion, Sclerp) {
-  libra::TranslationFirstDualQuaternion dq1;
+  // Initial DualQuaternion
+  libra::Quaternion q1_rot(0.0, 0.0, 0.0, 1.0);
+  libra::Vector<3> v1_translation;
+  v1_translation[0] = 0.0;
+  v1_translation[1] = 1.0;
+  v1_translation[2] = 0.0;
+  libra::TranslationFirstDualQuaternion dq1(v1_translation, q1_rot);
+
   // X 90deg rotation and X axis translation
   libra::Quaternion q2_rot(1.0, 0.0, 0.0, 1.0);
   libra::Vector<3> v2_translation;
@@ -137,15 +156,18 @@ TEST(TranslationFirstDualQuaternion, Sclerp) {
   // X 45deg rotation and X axis harf translation
   libra::TranslationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
 
+  // Check rotation
   EXPECT_NEAR(0.3826, dq_out.GetRealPart()[0], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
   EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
   EXPECT_NEAR(0.9239, dq_out.GetRealPart()[3], 1e-3);
-  EXPECT_NEAR(0.23097, dq_out.GetDualPart()[0], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[1], 1e-3);
-  EXPECT_NEAR(0.0, dq_out.GetDualPart()[2], 1e-3);
-  EXPECT_NEAR(-0.0957, dq_out.GetDualPart()[3], 1e-3);
 
+  // Check rotation
+  EXPECT_NEAR(0.5, dq_out.GetTranslationVector()[0], 1e-3);
+  EXPECT_NEAR(1.0, dq_out.GetTranslationVector()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetTranslationVector()[2], 1e-3);
+
+  // Check vector transform
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
   v_in[1] = 1.0;

--- a/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
@@ -89,10 +89,10 @@ TEST(TranslationFirstDualQuaternion, Integral) {
   velocity[0] = 1.0;
   velocity[1] = 0.0;
   velocity[2] = 0.0;
-  double dt = 0.1;
+  double dt = 0.01;
 
   // Integration
-  for (int i = 0; i < 900; i++) {
+  for (int i = 0; i < 9000; i++) {
     dq = dq.Integrate(omega, velocity, dt);
   }
 
@@ -103,21 +103,21 @@ TEST(TranslationFirstDualQuaternion, Integral) {
   EXPECT_NEAR(0.7071, dq.GetRealPart()[3], 1e-3);
 
   // Check transition
-  EXPECT_NEAR(90.0, dq.GetTranslationVector()[0], 1e-1);
-  EXPECT_NEAR(1.0, dq.GetTranslationVector()[1], 1e-1);
-  EXPECT_NEAR(0.0, dq.GetTranslationVector()[2], 1e-1);
+  EXPECT_NEAR(90.0, dq.GetTranslationVector()[0], 1e-2);
+  EXPECT_NEAR(1.0, dq.GetTranslationVector()[1], 1e-2);
+  EXPECT_NEAR(0.0, dq.GetTranslationVector()[2], 1e-2);
 
   // Check vector transform
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
-  v_in[1] = 0.0;
+  v_in[1] = 1.0;
   v_in[2] = 1.0;
 
   libra::Vector<3> v_out = dq.TransformVector(v_in);
 
-  EXPECT_NEAR(91.0, v_out[0], 1e-1);
-  EXPECT_NEAR(-1.0, v_out[1], 1e-1);
-  EXPECT_NEAR(1.0, v_out[2], 1e-1);
+  EXPECT_NEAR(91.0, v_out[0], 1e-2);
+  EXPECT_NEAR(-1.0, v_out[1], 1e-2);
+  EXPECT_NEAR(2.0, v_out[2], 1e-2);
 }
 
 TEST(TranslationFirstDualQuaternion, SclerpTranslationOnly) {

--- a/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
@@ -1,0 +1,142 @@
+#include <gtest/gtest.h>
+
+#include "../src/Library/math/TranslationFirstDualQuaternion.hpp"
+
+TEST(TranslationFirstDualQuaternion, ConstructorFromRotationTranslation) {
+  libra::Quaternion q_rot(1.0, 0.0, 0.0, 1.0);  // 90deg rotation around X axis
+  libra::Vector<3> v_translation;
+  v_translation[0] = 0.0;
+  v_translation[1] = 0.0;
+  v_translation[2] = 2.0;
+  libra::TranslationFirstDualQuaternion dq(v_translation, q_rot);
+
+  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(-1.0 / sqrt(2.0), dq.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(1.0 / sqrt(2.0), dq.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.0, dq.GetDualPart()[3]);
+
+  libra::Vector<3> v_out = dq.GetTranslationVector();
+  EXPECT_DOUBLE_EQ(v_translation[0], v_out[0]);
+  EXPECT_DOUBLE_EQ(v_translation[1], v_out[1]);
+  EXPECT_DOUBLE_EQ(v_translation[2], v_out[2]);
+}
+
+TEST(TranslationFirstDualQuaternion, Normalize) {
+  libra::DualQuaternion dq(0, 0, 0, 2, 0, 0, 1, 0);
+  libra::TranslationFirstDualQuaternion dq_in(dq);
+  libra::TranslationFirstDualQuaternion dq_out = dq_in.CalcNormalizedRotationQauternion();
+
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(2.0, dq_in.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(1.0, dq_in.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[3]);
+
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(1.0, dq_out.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(2.0, dq_out.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.0, dq_out.GetDualPart()[3]);
+
+  dq_in.NormalizeRotationQauternion();
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[1]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetRealPart()[2]);
+  EXPECT_DOUBLE_EQ(1.0, dq_in.GetRealPart()[3]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[0]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[1]);
+  EXPECT_DOUBLE_EQ(2.0, dq_in.GetDualPart()[2]);
+  EXPECT_DOUBLE_EQ(0.0, dq_in.GetDualPart()[3]);
+}
+
+TEST(TranslationFirstDualQuaternion, Integral) {
+  libra::TranslationFirstDualQuaternion dq;
+  libra::Vector<3> omega;
+  omega[0] = 0.01745329;
+  omega[1] = 0.0;
+  omega[2] = 0.0;
+  libra::Vector<3> velocity;
+  velocity[0] = 1.0;
+  velocity[1] = 0.0;
+  velocity[2] = 0.0;
+  double dt = 0.1;
+
+  for (int i = 0; i < 900; i++) {
+    dq = dq.Integrate(omega, velocity, dt);
+  }
+
+  EXPECT_NEAR(0.7071, dq.GetRealPart()[0], 1e-3);
+  EXPECT_NEAR(0.0, dq.GetRealPart()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq.GetRealPart()[2], 1e-3);
+  EXPECT_NEAR(0.7071, dq.GetRealPart()[3], 1e-3);
+
+  libra::Vector<3> v_in;
+  v_in[0] = 1.0;
+  v_in[1] = 1.0;
+  v_in[2] = 0.0;
+
+  libra::Vector<3> v_out = dq.TransformVector(v_in);
+
+  EXPECT_NEAR(91.0, v_out[0], 1e-1);
+  EXPECT_NEAR(0.0, v_out[1], 1e-1);
+  EXPECT_NEAR(1.0, v_out[2], 1e-1);
+}
+
+TEST(TranslationFirstDualQuaternion, SclerpTranslationOnly) {
+  libra::DualQuaternion dq1(0, 0, 0, 1, 0, 0, 0, 0);
+  libra::DualQuaternion dq2(0, 0, 0, 1, 1, 0, 0, 0);
+
+  libra::DualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
+
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[0], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
+  EXPECT_NEAR(1.0, dq_out.GetRealPart()[3], 1e-3);
+  EXPECT_NEAR(0.5, dq_out.GetDualPart()[0], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetDualPart()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetDualPart()[2], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetDualPart()[3], 1e-3);
+}
+
+TEST(TranslationFirstDualQuaternion, Sclerp) {
+  libra::TranslationFirstDualQuaternion dq1;
+  // X 90deg rotation and X axis translation
+  libra::Quaternion q2_rot(1.0, 0.0, 0.0, 1.0);
+  libra::Vector<3> v2_translation;
+  v2_translation[0] = 1.0;
+  v2_translation[1] = 0.0;
+  v2_translation[2] = 0.0;
+  libra::TranslationFirstDualQuaternion dq2(v2_translation, q2_rot);
+
+  // X 45deg rotation and X axis harf translation
+  libra::TranslationFirstDualQuaternion dq_out = libra::Sclerp(dq1, dq2, 0.5);
+
+  EXPECT_NEAR(0.3826, dq_out.GetRealPart()[0], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetRealPart()[2], 1e-3);
+  EXPECT_NEAR(0.9239, dq_out.GetRealPart()[3], 1e-3);
+  EXPECT_NEAR(0.23097, dq_out.GetDualPart()[0], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetDualPart()[1], 1e-3);
+  EXPECT_NEAR(0.0, dq_out.GetDualPart()[2], 1e-3);
+  EXPECT_NEAR(-0.0957, dq_out.GetDualPart()[3], 1e-3);
+
+  libra::Vector<3> v_in;
+  v_in[0] = 1.0;
+  v_in[1] = 1.0;
+  v_in[2] = 0.0;
+
+  libra::Vector<3> v_out = dq_out.TransformVector(v_in);
+  EXPECT_NEAR(1.5, v_out[0], 1e-3);
+  EXPECT_NEAR(0.7071, v_out[1], 1e-3);
+  EXPECT_NEAR(0.7071, v_out[2], 1e-3);
+}

--- a/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
+++ b/s2e-ff/test/TestTranslationFirstDualQuaternion.cpp
@@ -60,9 +60,17 @@ TEST(TranslationFirstDualQuaternion, Normalize) {
 }
 
 TEST(TranslationFirstDualQuaternion, Integral) {
-  libra::TranslationFirstDualQuaternion dq;
+  // Initial DualQuaternion
+  libra::Quaternion q_rot(0.0, 0.0, 0.0, 1.0);
+  libra::Vector<3> v_translation;
+  v_translation[0] = 0.0;
+  v_translation[1] = 1.0;
+  v_translation[2] = 0.0;
+  libra::TranslationFirstDualQuaternion dq(v_translation, q_rot);
+
+  // Kinematics condition
   libra::Vector<3> omega;
-  omega[0] = 0.01745329;
+  omega[0] = 0.01745329;  // 1 deg/s
   omega[1] = 0.0;
   omega[2] = 0.0;
   libra::Vector<3> velocity;
@@ -71,24 +79,32 @@ TEST(TranslationFirstDualQuaternion, Integral) {
   velocity[2] = 0.0;
   double dt = 0.1;
 
+  // Integration
   for (int i = 0; i < 900; i++) {
     dq = dq.Integrate(omega, velocity, dt);
   }
 
+  // Check rotation
   EXPECT_NEAR(0.7071, dq.GetRealPart()[0], 1e-3);
   EXPECT_NEAR(0.0, dq.GetRealPart()[1], 1e-3);
   EXPECT_NEAR(0.0, dq.GetRealPart()[2], 1e-3);
   EXPECT_NEAR(0.7071, dq.GetRealPart()[3], 1e-3);
 
+  // Check transition
+  EXPECT_NEAR(90.0, dq.GetTranslationVector()[0], 1e-1);
+  EXPECT_NEAR(1.0, dq.GetTranslationVector()[1], 1e-1);
+  EXPECT_NEAR(0.0, dq.GetTranslationVector()[2], 1e-1);
+
+  // Check frame conversion
   libra::Vector<3> v_in;
   v_in[0] = 1.0;
-  v_in[1] = 1.0;
-  v_in[2] = 0.0;
+  v_in[1] = 0.0;
+  v_in[2] = 1.0;
 
   libra::Vector<3> v_out = dq.TransformVector(v_in);
 
   EXPECT_NEAR(91.0, v_out[0], 1e-1);
-  EXPECT_NEAR(0.0, v_out[1], 1e-1);
+  EXPECT_NEAR(-1.0, v_out[1], 1e-1);
   EXPECT_NEAR(1.0, v_out[2], 1e-1);
 }
 


### PR DESCRIPTION
## 概要
Modify dual quaternion

## Issue
- #5 

## 詳細
The bugs in dual quaternion calculations were fixed especially in Sclerp function.  
The RotationFirst and TranslationFirst dual quaternion were added.

## 検証結果
I confirmed that the output of the Sclerp function is the same as the [Robotics dual quaternion toolbox](https://jp.mathworks.com/matlabcentral/fileexchange/71397-robotics-dual-quaternion-toolbox)

## 影響範囲
mid

## 補足
NA

## 注意
NA