### PR TITLE
Fix component algorithm

### DIFF
--- a/s2e-ff/CMakeLists.txt
+++ b/s2e-ff/CMakeLists.txt
@@ -45,6 +45,7 @@ add_subdirectory(${S2E_CORE_DIR}/src/simulation s2e_core/simulation)
 
 set(SOURCE_FILES
   src/s2e_ff.cpp
+  src/components/aocs/corner_cube_reflector.cpp
   src/components/aocs/relative_distance_sensor.cpp
   src/components/aocs/relative_position_sensor.cpp
   src/components/aocs/relative_attitude_sensor.cpp

--- a/s2e-ff/src/components/aocs/corner_cube_reflector.cpp
+++ b/s2e-ff/src/components/aocs/corner_cube_reflector.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file corner_cube_reflector.cpp
+ * @brief Corner cube reflector
+ */
+
+#include "./corner_cube_reflector.hpp"
+
+CornerCubeReflector::CornerCubeReflector(const int prescaler, ClockGenerator* clock_gen) : Component(prescaler, clock_gen), dynamics_(nullptr){};
+
+CornerCubeReflector::CornerCubeReflector(const int prescaler, ClockGenerator* clock_gen, const std::string file_name, const Dynamics* dynamics,
+                                         const size_t id)
+    : Component(prescaler, clock_gen), dynamics_(dynamics) {
+  Initialize(file_name, id);
+}
+
+void CornerCubeReflector::MainRoutine(int count) { Update(count); }
+
+void CornerCubeReflector::Update(int count) {
+  if (count_ >= count) return;
+  // Body -> Inertial frame
+  libra::Vector<3> spacecraft_position_i2b_m = dynamics_->GetOrbit().GetPosition_i_m();
+  libra::Quaternion spacecraft_attitude_i2b = dynamics_->GetAttitude().GetQuaternion_i2b();
+  libra::TranslationFirstDualQuaternion dual_quaternion_i2b(-spacecraft_position_i2b_m, spacecraft_attitude_i2b.Conjugate());
+
+  // Component -> Inertial frame
+  libra::TranslationFirstDualQuaternion dual_quaternion_c2i = dual_quaternion_i2b.QuaternionConjugate() * dual_quaternion_c2b_;
+
+  corner_cube_reflector_position_i_m_ = dual_quaternion_c2i.TransformVector(libra::Vector<3>{0.0});
+  corner_cube_reflector_normal_direction_i_ = dual_quaternion_c2i.TransformVector(normal_direction_c_) - corner_cube_reflector_position_i_m_;
+
+  count_ = count;
+}
+
+std::string CornerCubeReflector::GetLogHeader() const {
+  std::string str_tmp = "";
+
+  return str_tmp;
+}
+
+std::string CornerCubeReflector::GetLogValue() const {
+  std::string str_tmp = "";
+
+  return str_tmp;
+}
+
+void CornerCubeReflector::Initialize(const std::string file_name, const size_t id) {
+  IniAccess ini_file(file_name);
+  std::string name = "CORNER_CUBE_REFLECTOR_";
+  const std::string section_name = name + std::to_string(static_cast<long long>(id));
+
+  libra::Quaternion quaternion_b2c;
+  ini_file.ReadQuaternion(section_name.c_str(), "quaternion_b2c", quaternion_b2c);
+  libra::Vector<3> position_b_m;
+  ini_file.ReadVector(section_name.c_str(), "position_b_m", position_b_m);
+  dual_quaternion_c2b_ = libra::TranslationFirstDualQuaternion(-position_b_m, quaternion_b2c.Conjugate()).QuaternionConjugate();
+
+  ini_file.ReadVector(section_name.c_str(), "normal_direction_c", normal_direction_c_);
+  reflectable_angle_rad_ = ini_file.ReadDouble(section_name.c_str(), "reflectable_angle_rad");
+}

--- a/s2e-ff/src/components/aocs/corner_cube_reflector.hpp
+++ b/s2e-ff/src/components/aocs/corner_cube_reflector.hpp
@@ -6,6 +6,7 @@
 #ifndef S2E_COMPONENTS_CORNER_CUBE_REFLECTOR_HPP_
 #define S2E_COMPONENTS_CORNER_CUBE_REFLECTOR_HPP_
 
+#include <components/base/component.hpp>
 #include <dynamics/dynamics.hpp>
 #include <library/initialize/initialize_file_access.hpp>
 #include <library/math/vector.hpp>
@@ -16,50 +17,47 @@
  * @class CornerCubeReflector
  * @brief Corner Cube Reflector
  */
-class CornerCubeReflector {
+class CornerCubeReflector : public Component {
  public:
   /**
    * @fn CornerCubeReflector
    * @brief Constructor
    */
-  CornerCubeReflector() : dynamics_(nullptr) {}
+  CornerCubeReflector(const int prescaler, ClockGenerator* clock_gen);
   /**
    * @fn CornerCubeReflector
    * @brief Constructor
    */
-  CornerCubeReflector(const std::string file_name, const Dynamics* dynamics, const size_t id = 0) : dynamics_(dynamics) { Initialize(file_name, id); }
+  CornerCubeReflector(const int prescaler, ClockGenerator* clock_gen, const std::string file_name, const Dynamics* dynamics, const size_t id = 0);
   /**
    * @fn ~CornerCubeReflector
    * @brief Destructor
    */
   ~CornerCubeReflector() {}
 
-  inline libra::Vector<3> GetReflectorPosition_i_m() const {
-    libra::Vector<3> spacecraft_position_i2b_m = dynamics_->GetOrbit().GetPosition_i_m();
-    libra::Quaternion spacecraft_attitude_i2b = dynamics_->GetAttitude().GetQuaternion_i2b();
-    libra::TranslationFirstDualQuaternion dual_quaternion_i2b(-spacecraft_position_i2b_m, spacecraft_attitude_i2b.Conjugate());
+  // ComponentBase override function
+  /**
+   * @fn MainRoutine
+   * @brief Main routine
+   */
+  void MainRoutine(int count);
 
-    // Component -> Inertial frame
-    libra::TranslationFirstDualQuaternion dual_quaternion_c2i = dual_quaternion_i2b.QuaternionConjugate() * dual_quaternion_c2b_;
+  // Override ILoggable
+  /**
+   * @fn GetLogHeader
+   * @brief Override GetLogHeader function of ILoggable
+   */
+  virtual std::string GetLogHeader() const;
+  /**
+   * @fn GetLogValue
+   * @brief Override GetLogValue function of ILoggable
+   */
+  virtual std::string GetLogValue() const;
 
-    return dual_quaternion_c2i.TransformVector(libra::Vector<3>{0.0});
-  }
+  void Update(int count);
 
-  inline libra::Vector<3> GetNormalDirection_i() const {
-    // Body -> Inertial frame
-    libra::Vector<3> spacecraft_position_i2b_m = dynamics_->GetOrbit().GetPosition_i_m();
-    libra::Quaternion spacecraft_attitude_i2b = dynamics_->GetAttitude().GetQuaternion_i2b();
-    libra::TranslationFirstDualQuaternion dual_quaternion_i2b(-spacecraft_position_i2b_m, spacecraft_attitude_i2b.Conjugate());
-
-    // Component -> Inertial frame
-    libra::TranslationFirstDualQuaternion dual_quaternion_c2i = dual_quaternion_i2b.QuaternionConjugate() * dual_quaternion_c2b_;
-
-    libra::Vector<3> reflector_position_i_m = dual_quaternion_c2i.TransformVector(libra::Vector<3>{0.0});
-    libra::Vector<3> normal_direction_i = dual_quaternion_c2i.TransformVector(normal_direction_c_);
-    normal_direction_i -= reflector_position_i_m;
-
-    return normal_direction_i;
-  }
+  inline libra::Vector<3> GetReflectorPosition_i_m() const { return corner_cube_reflector_position_i_m_; }
+  inline libra::Vector<3> GetNormalDirection_i() const { return corner_cube_reflector_normal_direction_i_; }
 
   inline double GetReflectableAngle_rad() const { return reflectable_angle_rad_; }
 
@@ -68,24 +66,16 @@ class CornerCubeReflector {
   double reflectable_angle_rad_ = 0.0;                         //!< Reflectable half angle from the normal direction [rad]
   libra::TranslationFirstDualQuaternion dual_quaternion_c2b_;  //!< Dual quaternion from body to component frame
 
+  libra::Vector<3> corner_cube_reflector_position_i_m_{0.0};
+  libra::Vector<3> corner_cube_reflector_normal_direction_i_{0.0};
+
+  int count_ = 0;
+
   // Reference
   const Dynamics* dynamics_;
 
   // Functions
-  void Initialize(const std::string file_name, const size_t id = 0) {
-    IniAccess ini_file(file_name);
-    std::string name = "CORNER_CUBE_REFLECTOR_";
-    const std::string section_name = name + std::to_string(static_cast<long long>(id));
-
-    libra::Quaternion quaternion_b2c;
-    ini_file.ReadQuaternion(section_name.c_str(), "quaternion_b2c", quaternion_b2c);
-    libra::Vector<3> position_b_m;
-    ini_file.ReadVector(section_name.c_str(), "position_b_m", position_b_m);
-    dual_quaternion_c2b_ = libra::TranslationFirstDualQuaternion(-position_b_m, quaternion_b2c.Conjugate()).QuaternionConjugate();
-
-    ini_file.ReadVector(section_name.c_str(), "normal_direction_c", normal_direction_c_);
-    reflectable_angle_rad_ = ini_file.ReadDouble(section_name.c_str(), "reflectable_angle_rad");
-  }
+  void Initialize(const std::string file_name, const size_t id = 0);
 };
 
 #endif  // S2E_COMPONENTS_CORNER_CUBE_REFLECTOR_HPP_

--- a/s2e-ff/src/components/aocs/laser_distance_meter.cpp
+++ b/s2e-ff/src/components/aocs/laser_distance_meter.cpp
@@ -29,6 +29,7 @@ void LaserDistanceMeter::MainRoutine(int count) {
   is_reflected_ = false;
   for (size_t reflector_id = 0; reflector_id < number_of_reflectors; reflector_id++) {
     // Get reflector information
+    inter_spacecraft_communication_.GetCornerCubeReflector(reflector_id).Update(count);
     libra::Vector<3> reflector_position_i_m = inter_spacecraft_communication_.GetCornerCubeReflector(reflector_id).GetReflectorPosition_i_m();
     libra::Vector<3> reflector_normal_direction_i = inter_spacecraft_communication_.GetCornerCubeReflector(reflector_id).GetNormalDirection_i();
 

--- a/s2e-ff/src/components/aocs/laser_emitter.cpp
+++ b/s2e-ff/src/components/aocs/laser_emitter.cpp
@@ -8,10 +8,11 @@
  * @fn LaserEmitter
  * @brief Constructor
  */
-LaserEmitter::LaserEmitter(const Dynamics& dynamics, libra::Vector<3> emitting_direction_c, double emission_angle_rad,
-                           libra::TranslationFirstDualQuaternion dual_quaternion_c2b, double emission_power_W, double radius_beam_waist_m,
-                           double rayleigh_length_m, double rayleigh_length_offset_m, double wavelength_m)
-    : GaussianBeamBase(wavelength_m, radius_beam_waist_m, emission_power_W),
+LaserEmitter::LaserEmitter(const int prescaler, ClockGenerator* clock_gen, const Dynamics& dynamics, libra::Vector<3> emitting_direction_c,
+                           double emission_angle_rad, libra::TranslationFirstDualQuaternion dual_quaternion_c2b, double emission_power_W,
+                           double radius_beam_waist_m, double rayleigh_length_m, double rayleigh_length_offset_m, double wavelength_m)
+    : Component(prescaler, clock_gen),
+      GaussianBeamBase(wavelength_m, radius_beam_waist_m, emission_power_W),
       dynamics_(dynamics),
       emitting_direction_c_(emitting_direction_c),
       emission_angle_rad_(emission_angle_rad),
@@ -19,7 +20,39 @@ LaserEmitter::LaserEmitter(const Dynamics& dynamics, libra::Vector<3> emitting_d
       rayleigh_length_m_(rayleigh_length_m),
       rayleigh_length_offset_m_(rayleigh_length_offset_m) {}
 
-LaserEmitter InitializeLaserEmitter(const std::string file_name, const Dynamics& dynamics, const size_t id) {
+void LaserEmitter::MainRoutine(int count) { Update(count); }
+
+void LaserEmitter::Update(int count) {
+  if (count_ >= count) return;
+  // Body -> Inertial frame
+  libra::Vector<3> spacecraft_position_i2b_m = dynamics_.GetOrbit().GetPosition_i_m();
+  libra::Quaternion spacecraft_attitude_i2b = dynamics_.GetAttitude().GetQuaternion_i2b();
+  libra::TranslationFirstDualQuaternion dual_quaternion_i2b(-spacecraft_position_i2b_m, spacecraft_attitude_i2b.Conjugate());
+
+  // Component -> Inertial frame
+  libra::TranslationFirstDualQuaternion dual_quaternion_c2i = dual_quaternion_i2b.QuaternionConjugate() * dual_quaternion_c2b_;
+
+  laser_position_i_m_ = dual_quaternion_c2i.TransformVector(libra::Vector<3>{0.0});
+
+  laser_emitting_direction_i_ = dual_quaternion_c2i.TransformVector(emitting_direction_c_) - laser_position_i_m_;
+
+  count_ = count;
+}
+
+std::string LaserEmitter::GetLogHeader() const {
+  std::string str_tmp = "";
+
+  return str_tmp;
+}
+
+std::string LaserEmitter::GetLogValue() const {
+  std::string str_tmp = "";
+
+  return str_tmp;
+}
+
+LaserEmitter InitializeLaserEmitter(const int prescaler, ClockGenerator* clock_gen, const std::string file_name, const Dynamics& dynamics,
+                                    const size_t id) {
   IniAccess ini_file(file_name);
   std::string name = "LASER_EMITTER_";
   const std::string section_name = name + std::to_string(static_cast<long long>(id));
@@ -43,8 +76,8 @@ LaserEmitter InitializeLaserEmitter(const std::string file_name, const Dynamics&
 
   double wavelength_m = libra::pi * radius_beam_waist_m * radius_beam_waist_m / rayleigh_length_m;
 
-  LaserEmitter laser_emitter(dynamics, emitting_direction_c, emission_angle_rad, dual_quaternion_c2b, emission_power_W, radius_beam_waist_m,
-                             rayleigh_length_m, rayleigh_length_offset_m, wavelength_m);
+  LaserEmitter laser_emitter(prescaler, clock_gen, dynamics, emitting_direction_c, emission_angle_rad, dual_quaternion_c2b, emission_power_W,
+                             radius_beam_waist_m, rayleigh_length_m, rayleigh_length_offset_m, wavelength_m);
 
   return laser_emitter;
 };

--- a/s2e-ff/src/components/aocs/laser_emitter.hpp
+++ b/s2e-ff/src/components/aocs/laser_emitter.hpp
@@ -72,8 +72,6 @@ class LaserEmitter : public Component, public GaussianBeamBase {
 
   libra::Vector<3> laser_position_i_m_{0.0};
   libra::Vector<3> laser_emitting_direction_i_{0.0};
-  libra::Vector<3> previous_laser_position_i_m_{0.0};
-  libra::Vector<3> previous_laser_emitting_direction_i_{0.0};
 
   int count_ = 0;
 

--- a/s2e-ff/src/components/aocs/laser_emitter.hpp
+++ b/s2e-ff/src/components/aocs/laser_emitter.hpp
@@ -6,6 +6,7 @@
 #ifndef S2E_COMPONENTS_LASER_EMITTER_HPP_
 #define S2E_COMPONENTS_LASER_EMITTER_HPP_
 
+#include <components/base/component.hpp>
 #include <dynamics/dynamics.hpp>
 #include <library/initialize/initialize_file_access.hpp>
 #include <library/math/vector.hpp>
@@ -17,15 +18,15 @@
  * @class LaserEmitter
  * @brief Laser Emitter
  */
-class LaserEmitter : public GaussianBeamBase {
+class LaserEmitter : public Component, public GaussianBeamBase {
  public:
   /**
    * @fn LaserEmitter
    * @brief Constructor
    */
-  LaserEmitter(const Dynamics& dynamics, libra::Vector<3> emitting_direction_c, double emission_angle_rad,
-               libra::TranslationFirstDualQuaternion dual_quaternion_c2b, double emission_power_W, double radius_beam_waist_m,
-               double rayleigh_length_m, double rayleigh_length_offset_m, double wavelength_m);
+  LaserEmitter(const int prescaler, ClockGenerator* clock_gen, const Dynamics& dynamics, libra::Vector<3> emitting_direction_c,
+               double emission_angle_rad, libra::TranslationFirstDualQuaternion dual_quaternion_c2b, double emission_power_W,
+               double radius_beam_waist_m, double rayleigh_length_m, double rayleigh_length_offset_m, double wavelength_m);
 
   /**
    * @fn ~LaserEmitter
@@ -33,32 +34,29 @@ class LaserEmitter : public GaussianBeamBase {
    */
   ~LaserEmitter() {}
 
-  inline libra::Vector<3> GetLaserPosition_i_m() const {
-    libra::Vector<3> spacecraft_position_i2b_m = dynamics_.GetOrbit().GetPosition_i_m();
-    libra::Quaternion spacecraft_attitude_i2b = dynamics_.GetAttitude().GetQuaternion_i2b();
-    libra::TranslationFirstDualQuaternion dual_quaternion_i2b(-spacecraft_position_i2b_m, spacecraft_attitude_i2b.Conjugate());
+  // ComponentBase override function
+  /**
+   * @fn MainRoutine
+   * @brief Main routine
+   */
+  void MainRoutine(int count);
 
-    // Component -> Inertial frame
-    libra::TranslationFirstDualQuaternion dual_quaternion_c2i = dual_quaternion_i2b.QuaternionConjugate() * dual_quaternion_c2b_;
+  // Override ILoggable
+  /**
+   * @fn GetLogHeader
+   * @brief Override GetLogHeader function of ILoggable
+   */
+  virtual std::string GetLogHeader() const;
+  /**
+   * @fn GetLogValue
+   * @brief Override GetLogValue function of ILoggable
+   */
+  virtual std::string GetLogValue() const;
 
-    return dual_quaternion_c2i.TransformVector(libra::Vector<3>{0.0});
-  }
+  void Update(int count);
 
-  inline libra::Vector<3> GetEmittingDirection_i() const {
-    // Body -> Inertial frame
-    libra::Vector<3> spacecraft_position_i2b_m = dynamics_.GetOrbit().GetPosition_i_m();
-    libra::Quaternion spacecraft_attitude_i2b = dynamics_.GetAttitude().GetQuaternion_i2b();
-    libra::TranslationFirstDualQuaternion dual_quaternion_i2b(-spacecraft_position_i2b_m, spacecraft_attitude_i2b.Conjugate());
-
-    // Component -> Inertial frame
-    libra::TranslationFirstDualQuaternion dual_quaternion_c2i = dual_quaternion_i2b.QuaternionConjugate() * dual_quaternion_c2b_;
-
-    libra::Vector<3> laser_position_i_m = dual_quaternion_c2i.TransformVector(libra::Vector<3>{0.0});
-    libra::Vector<3> emitting_direction_i = dual_quaternion_c2i.TransformVector(emitting_direction_c_);
-    emitting_direction_i -= laser_position_i_m;
-
-    return emitting_direction_i;
-  }
+  inline libra::Vector<3> GetLaserPosition_i_m() const { return laser_position_i_m_; }
+  inline libra::Vector<3> GetEmittingDirection_i() const { return laser_emitting_direction_i_; }
 
   inline double GetEmissionAngle_rad() const { return emission_angle_rad_; }
   inline double GetRayleighLength_m() const { return rayleigh_length_m_; }
@@ -72,10 +70,18 @@ class LaserEmitter : public GaussianBeamBase {
   double rayleigh_length_m_ = 0.0;         //!< Rayleigh length (range) of the laser [m]
   double rayleigh_length_offset_m_ = 0.0;  //!< Rayleigh length (range) position offset of the laser [m]
 
+  libra::Vector<3> laser_position_i_m_{0.0};
+  libra::Vector<3> laser_emitting_direction_i_{0.0};
+  libra::Vector<3> previous_laser_position_i_m_{0.0};
+  libra::Vector<3> previous_laser_emitting_direction_i_{0.0};
+
+  int count_ = 0;
+
   // Reference
   const Dynamics& dynamics_;
 };
 
-LaserEmitter InitializeLaserEmitter(const std::string file_name, const Dynamics& dynamics, const size_t id = 0);
+LaserEmitter InitializeLaserEmitter(const int prescaler, ClockGenerator* clock_gen, const std::string file_name, const Dynamics& dynamics,
+                                    const size_t id = 0);
 
 #endif  // S2E_COMPONENTS_LASER_EMITTER_HPP_

--- a/s2e-ff/src/components/aocs/qpd_positioning_sensor.cpp
+++ b/s2e-ff/src/components/aocs/qpd_positioning_sensor.cpp
@@ -38,6 +38,7 @@ void QpdPositioningSensor::MainRoutine(int count) {
   is_received_laser_ = false;
   for (size_t laser_id = 0; laser_id < number_of_laser_emitters; laser_id++) {
     // Get laser information
+    inter_spacecraft_communication_.GetLaserEmitter(laser_id).Update(count);
     libra::Vector<3> laser_position_i_m = inter_spacecraft_communication_.GetLaserEmitter(laser_id).GetLaserPosition_i_m();
     libra::Vector<3> laser_emitting_direction_i = inter_spacecraft_communication_.GetLaserEmitter(laser_id).GetEmittingDirection_i();
 

--- a/s2e-ff/src/components/aocs/qpd_positioning_sensor.hpp
+++ b/s2e-ff/src/components/aocs/qpd_positioning_sensor.hpp
@@ -98,6 +98,8 @@ class QpdPositioningSensor : public Component, public ILoggable {
   std::vector<double>
       qpd_sensor_voltage_ratio_z_list_;  //!< List of `qpd_sensor_output_z_axis_V / qpd_sensor_output_sum_V` at each point on the z-axis.
 
+  size_t qpd_positioning_sensor_id_ = 0;
+
   // Reference
   const Dynamics& dynamics_;
   const FfInterSpacecraftCommunication& inter_spacecraft_communication_;

--- a/s2e-ff/src/simulation/spacecraft/ff_components_2.cpp
+++ b/s2e-ff/src/simulation/spacecraft/ff_components_2.cpp
@@ -33,7 +33,7 @@ FfComponents2::FfComponents2(const Dynamics* dynamics, const Structure* structur
   IniAccess laser_emitter_file(file_name);
   size_t number_of_laser_emitters = laser_emitter_file.ReadInt("GENERAL", "number_of_laser_emitters");
   for (size_t id = 0; id < number_of_laser_emitters; id++) {
-    laser_emitters_.push_back(new LaserEmitter(InitializeLaserEmitter(file_name, *dynamics_, id)));
+    laser_emitters_.push_back(new LaserEmitter(InitializeLaserEmitter(1, clock_gen, file_name, *dynamics_, id)));
   }
   inter_spacecraft_communication.SetLaserEmitter(laser_emitters_);
 

--- a/s2e-ff/src/simulation/spacecraft/ff_components_2.cpp
+++ b/s2e-ff/src/simulation/spacecraft/ff_components_2.cpp
@@ -24,7 +24,7 @@ FfComponents2::FfComponents2(const Dynamics* dynamics, const Structure* structur
   IniAccess corner_cube_file(file_name);
   size_t number_of_reflectors = corner_cube_file.ReadInt("GENERAL", "number_of_reflectors");
   for (size_t id = 0; id < number_of_reflectors; id++) {
-    corner_cube_reflectors_.push_back(new CornerCubeReflector(file_name, dynamics_, id));
+    corner_cube_reflectors_.push_back(new CornerCubeReflector(1, clock_gen, file_name, dynamics_, id));
   }
   inter_spacecraft_communication.SetCornerCubeReflector(corner_cube_reflectors_);
 


### PR DESCRIPTION
## 概要
Fix component algorithm

## Issue
- N/A

## 詳細
相対位置・姿勢観測センサに関するコンポーネントのアルゴリズムを改善
- corner cube reflector と laser emitterに関して
  - コンポーネントクラスを継承させて各ステップごとにposition_i_mなどを計算させるようにした。
  - 理由：
    - 今までの状況だと、複数衛星間で情報をやり取りする際に、その時点のposition_i_mではなく、1ステップ前や1ステップ後のposition_i_mを使用する場合があった。
      - 具体的に言うと、今の状態だとlaser_emitterがsatellite 1にあり、qpd_positioning_sensorが satellite 0にあるが、これを逆に搭載するとsatellite 1のqpd_positioning_sensorが状態量を更新するタイミングでlaser_emitterの状態量を更新するが、この時点において、S2E-FFの計算順序の観点から、すでにsatellite 0は1ステップ後の軌道情報を計算しているので、その値を用いてlaser_emitterの位置が計算されてしまう。このように、複数衛星間での情報をやり取りする際に、その時点での位置を確実に計算させることが重要であるので、Componentクラスを継承させて、衛星のdynamics_が更新されるタイミングとほとんど同じタイミングでコンポーネントを更新させるようにした。
        - このとき、上記に付随してまた別の問題が生じた。それは、番号の小さいsatelliteのコンポーネントから順番に計算するというアルゴリズムになっているため、番号の小さいsatelliteがlaser_emitterなどのデータを用いて相対位置を計算しようとしたときに、laser_emitterの位置はまだ更新されておらず、1ステップ前の値が残ってしまっている。そこで、Update関数を作成し、コンポを使用する際にはUpdate関数をたたくようにした。このUpdate関数は引数にcountを用いているため、異なるステップの状態のdynamicsを用いて計算することを防止している。
- qpd_positioning_sensorに関して
  - 位置を計算する際、配列を最初から順番に計算していて計算コストが高かったため、二分探索のアルゴリズムに変更した。

## 検証結果

![image](https://github.com/ut-issl/s2e-ff/assets/56018919/bc98c5b3-cbef-4ced-a2e0-be048f9aa5b6)


## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば

## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
