### PR TITLE
Destructer でlaser_emitterをdeleteし忘れていたので削除

### DIFF
--- a/s2e-ff/src/simulation/spacecraft/ff_components_2.cpp
+++ b/s2e-ff/src/simulation/spacecraft/ff_components_2.cpp
@@ -49,6 +49,9 @@ FfComponents2::~FfComponents2() {
   for (auto corner_cube_reflector : corner_cube_reflectors_) {
     delete corner_cube_reflector;
   }
+  for (auto laser_emitter : laser_emitters_) {
+    delete laser_emitter;
+  }
   // OBC must be deleted the last since it has com ports
   delete obc_;
 }


### PR DESCRIPTION
## 概要
Destructer でlaser_emitterをdeleteし忘れていたので削除

## Issue
- N/A

## 詳細
Destructer でlaser_emitterをdeleteし忘れていたので削除

## 検証結果
See CI

## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば

## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
